### PR TITLE
Harden custom package vername handling

### DIFF
--- a/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
@@ -128,6 +128,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.concurrent.Executors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import cn.sherlock.com.sun.media.sound.SF2Soundbank;
 
@@ -1616,7 +1618,7 @@ public class XServerDisplayActivity extends AppCompatActivity implements Navigat
                 Log.d(TAG, "Extracting fallback DXVK .tzst archive: " + dxvkWrapper);
                 TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, this, "dxwrapper/" + dxvkWrapper + ".tzst", windowsDir, onExtractFileListener);
 
-                if (compareVersion(StringUtils.parseNumber(dxvkWrapper), "2.4") < 0) {
+                if (compareVersion(dxvkWrapper, "2.4") < 0) {
                     Log.d(TAG, "Extracting d8vk as part of DXVK version " + dxvkWrapper);
                     TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, this, "dxwrapper/d8vk-" + DefaultVersion.D8VK + ".tzst", windowsDir, onExtractFileListener);
                 }
@@ -1660,24 +1662,39 @@ public class XServerDisplayActivity extends AppCompatActivity implements Navigat
     }
 
     private static int compareVersion(String varA, String varB) {
-        final String[] levelsA = varA.split("\\.");
-        final String[] levelsB = varB.split("\\.");
-        int minLen = Math.min(levelsA.length, levelsB.length);
-        int numA, numB;
+        int[] a = parseSemverLoose(varA);
+        int[] b = parseSemverLoose(varB);
 
-        for (int i = 0; i < minLen; i++) {
-            numA = Integer.parseInt(levelsA[i]);
-            numB = Integer.parseInt(levelsB[i]);
-            if (numA != numB)
-                return numA - numB;
-        }
-
-        if (levelsA.length != levelsB.length)
-            return levelsA.length - levelsB.length;
-
-        return 0;
+        if (a[0] != b[0]) return a[0] - b[0];
+        if (a[1] != b[1]) return a[1] - b[1];
+        return a[2] - b[2];
     }
 
+    private static final Pattern SEMVER_LOOSE = Pattern.compile("(\\d+)\\.(\\d+)(?:\\.(\\d+))?");
+
+    private static int[] parseSemverLoose(String s) {
+        if (s == null) return new int[]{0, 0, 0};
+
+        Matcher m = SEMVER_LOOSE.matcher(s);
+        if (!m.find()) {
+            return new int[]{0, 0, 0};
+        }
+
+        int major = safeParseInt(m.group(1));
+        int minor = safeParseInt(m.group(2));
+        int patch = safeParseInt(m.group(3));
+        return new int[]{major, minor, patch};
+    }
+
+    private static int safeParseInt(String s) {
+        if (s == null || s.isEmpty()) return 0;
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException ignored) {
+            return 0;
+        }
+    }
+    
     private void extractWinComponentFiles() {
         Log.d("XServerDisplayActivity", "Extracting WinComponents");
         File rootDir = imageFs.getRootDir();
@@ -1893,5 +1910,6 @@ public class XServerDisplayActivity extends AppCompatActivity implements Navigat
     }
 
 }
+
 
 

--- a/app/src/main/java/com/winlator/cmod/contentdialog/DXVKConfigDialog.java
+++ b/app/src/main/java/com/winlator/cmod/contentdialog/DXVKConfigDialog.java
@@ -24,6 +24,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class DXVKConfigDialog extends ContentDialog {
     public static final String DEFAULT_CONFIG = Container.DEFAULT_DXWRAPPERCONFIG;
@@ -37,6 +39,19 @@ public class DXVKConfigDialog extends ContentDialog {
     private final View llAsyncCache;
     private final Context context;
     private static List<String> dxvkVersions;
+    private static final Pattern SEMVER = Pattern.compile("(\\d+)\\.(\\d+)(?:\\.(\\d+))?");
+
+    private static Integer tryGetMajor(String s) {
+        if (s == null) return null;
+        Matcher m = SEMVER.matcher(s);
+        if (!m.find()) return null;
+        try {
+            return Integer.parseInt(m.group(1));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+    
     public static final String[] VKD3D_FEATURE_LEVEL = {"12_0", "12_1", "12_2", "11_1", "11_0", "10_1", "10_0", "9_3", "9_2", "9_1"};
 
     private static int compareVersion(String varA, String varB) {
@@ -118,9 +133,10 @@ public class DXVKConfigDialog extends ContentDialog {
                     ArrayList<String> versions = new ArrayList<>();
 
                     for (int i = 0; i < dxvkVersions.size(); i++) {
-                        int major = Integer.parseInt(dxvkVersions.get(i).split("\\.")[0]);
-                        if (major < 2)
+                        Integer major = tryGetMajor(dxvkVersions.get(i));
+                        if (major != null && major < 2) {
                             versions.add(dxvkVersions.get(i));
+                        }
                     }
 
                     dxvkVersions.removeAll(versions);
@@ -128,8 +144,11 @@ public class DXVKConfigDialog extends ContentDialog {
                     ArrayAdapter<String> adapter = new ArrayAdapter<>(context, android.R.layout.simple_spinner_dropdown_item, dxvkVersions);
                     sDXVKVersion.setAdapter(adapter);
 
-                    int major = Integer.parseInt(currentDXVKVersion.split("\\.")[0]);
-                    AppUtils.setSpinnerSelectionFromIdentifier(sDXVKVersion, (major >= 2) ? currentDXVKVersion : DefaultVersion.DXVK);
+                    Integer curMajor = tryGetMajor(currentDXVKVersion);
+                    AppUtils.setSpinnerSelectionFromIdentifier(
+                            sDXVKVersion,
+                            (curMajor != null && curMajor >= 2) ? currentDXVKVersion : DefaultVersion.DXVK
+                    );
                     updateConfigVisibility(getDXVKType(sDXVKVersion.getSelectedItemPosition()));
                 }
                 else {
@@ -186,9 +205,10 @@ public class DXVKConfigDialog extends ContentDialog {
             ArrayList<String> versions = new ArrayList<>();
 
             for (int i = 0; i < dxvkVersions.size(); i++) {
-                int major = Integer.parseInt(dxvkVersions.get(i).split("\\.")[0]);
-                if (major < 2)
+                Integer major = tryGetMajor(dxvkVersions.get(i));
+                if (major != null && major < 2) {
                     versions.add(dxvkVersions.get(i));
+                }
             }
 
             dxvkVersions.removeAll(versions);
@@ -196,8 +216,11 @@ public class DXVKConfigDialog extends ContentDialog {
             ArrayAdapter<String> adapter = new ArrayAdapter<>(context, android.R.layout.simple_spinner_dropdown_item, dxvkVersions);
             sDXVKVersion.setAdapter(adapter);
 
-            int major = Integer.parseInt(currentDXVKVersion.split("\\.")[0]);
-            AppUtils.setSpinnerSelectionFromIdentifier(sDXVKVersion, (major >= 2) ? currentDXVKVersion : DefaultVersion.DXVK);
+            Integer curMajor = tryGetMajor(currentDXVKVersion);
+            AppUtils.setSpinnerSelectionFromIdentifier(
+                    sDXVKVersion,
+                    (curMajor != null && curMajor >= 2) ? currentDXVKVersion : DefaultVersion.DXVK
+            );
         }
         else
             AppUtils.setSpinnerSelectionFromIdentifier(sDXVKVersion, currentDXVKVersion);
@@ -274,3 +297,4 @@ public class DXVKConfigDialog extends ContentDialog {
         spinner.setAdapter(adapter);
     }
 }
+

--- a/app/src/main/java/com/winlator/cmod/xenvironment/components/GuestProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/cmod/xenvironment/components/GuestProgramLauncherComponent.java
@@ -325,14 +325,6 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
         }
 
         envVars.put("LD_PRELOAD", ld_preload);
-
-        if (this.envVars.has("MANGOHUD")) {
-            this.envVars.remove("MANGOHUD");
-        }
-
-        if (this.envVars.has("MANGOHUD_CONFIG")) {
-            this.envVars.remove("MANGOHUD_CONFIG");
-        }
         
         // Merge any additional environment variables from external sources
         if (this.envVars != null) {
@@ -405,4 +397,5 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
             if (pid != -1) ProcessHelper.resumeProcess(pid);
         }
     }
+
 }


### PR DESCRIPTION
Fix: a long-standing crash caused by custom package version names that include prefix tokens.
Fix: Safe dxvkWrapper version parse (arm64ec-..)