### PR TITLE
Fix crash on unmapped key codes in onKeyEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,41 @@
 
+# Winlator Ludashi – Game Genie crash fix (Asus game manager)
 
-<p align="center">
-  <img src="logo.png" alt="Winlator Bionic" width="600">
-</p>
+### Overview
+This fork of Winlator Ludashi aims to fix a crash that occurs on my Rog Phone 9 Pro when the Game Genie (com.asus.gamewidget) service sends invalid key codes to the Winlator keyboard handler.
+The primary purpose of this repository is to prepare a pull request that addresses this issue in the upstream project.
 
-# Winlator Bionic
+### Problem description
+A fatal crash occurs in `Keyboard.onKeyEvent()` when Game Genie sends invalid keycodes (`851` or `861`) during the device's screen off/on lifecycle.
 
-Winlator is an Android application that lets you run Windows (x86\_64) applications with Wine. It supports standard `x86_64` containers using Box86/Box64, as well as `Arm64EC` containers which utilize FEXCore (for 64/32-bit) or an optional WowBox64 (for 32-bit).
+#### Exception details
+```
+FATAL EXCEPTION: main
+Process: com.winlator
+java.lang.ArrayIndexOutOfBoundsException: length=159 index=851
+    at com.winlator.xserver.Keyboard.onKeyEvent(Keyboard.java:104)
+Caused by: android.view.KeyEvent-JNI: java.lang.IllegalArgumentException: Invalid keycode 851
+```
 
-This is a fork of the **Winlator Bionic** project by [Pipetto-crypto](https://github.com/Pipetto-crypto/winlator).
+### Root cause
+1. Game Genie (com.asus.gamewidget) generates invalid `keycodes` `851`/`861`.
+2. `Keyboard.onKeyEvent(Keyboard.java:104)` uses `keys[keyCode]` without bounds checking.
+3. Because the array length is `159,` accessing `keys[851]` triggers an `ArrayIndexOutOfBoundsException`.
 
-and backup [Ludashi-backup](https://github.com/StevenMX-backup/Ludashi-Backup).
-## APK Build Explanations
-
-### what is Ludashi?
-
-The Ludashi Build is functionally identical to the standard Bionic app, but the package name has been renamed to mimic Ludashi, a popular benchmark app. Some Android phones — especially Xiaomi devices — may automatically enable performance mode when such apps are detected, potentially reducing throttling and boosting performance slightly.
-
-### Dev-Vanilla Build
-
-This is the standard, unmodified build. It uses the original package name, which allows it to be installed alongside other popular Winlator forks (like the coffincolors version) without any package conflicts.
-
-### RedMagic Build
-
-This build mimics the package name of Genshin Impact. This is specifically designed for RedMagic devices, as the phone's software may detect this package name to enable hardware-specific gaming enhancements, such as built-in frame generation (framegen). Using this build may unlock these features and improve performance on supported RedMagic phones.
-
-# Installation
-
-1.  Download and install the latest APK from this repository's [Releases section](https://github.com/StevenMXZ/Winlator-Ludashi/releases) (choose your preferred build: `dev-vanilla`, `ludashi`, or `redmagic`).
-2.  Launch the app and wait for the installation process to finish.
-
-# Useful Tips
-
-  - Here is a tutorial from ZeroKimchi channel on how to use Winlator Bionic:
-    https://youtu.be/EJDWZUGF9sk?si=e3Z-DdmMJSYKduWz
-  - If you are using an `x86_64` container and experiencing performance issues, try changing the Box86/Box64 preset to **Performance** in Container Settings -\> Advanced Tab.
-  - If you are using an `Arm64EC` container, try swapping between different FEXCore versions (2505,2507 etc) in the container settings for better compatibility or performance.
-  - For applications that use .NET Framework, try installing Wine Mono found in Start Menu -\> System Tools.
-  - If some older games don't open, try adding the environment variable MESA\_EXTENSION\_MAX\_YEAR=2003 in Container Settings -\> Environment Variables.
-  - Try running the games using the shortcut on the Winlator home screen, there you can define individual settings for each game.
-  - To speed up the installers, try changing the Box86/Box64 preset to Intermediate in Container Settings -\> Advanced Tab.
-
-# Additional Components & Updates
-
-You can find updated components (known as `wcps`) to improve compatibility and performance, as well as new drivers, at the links below:
-
-  - **Winlator Components (FEXCore, Box64/Box86, DXVK, etc.):**
-      - [StevenMXZ's Winlator-Contents Repository](https://github.com/StevenMXZ/Winlator-Contents)
-  - **Adreno GPU Drivers (Turnip):**
-      - [Kimchi's AdrenoToolsDrivers Releases](https://www.google.com/search?q=https://github.com/K11MCH1/AdrenoToolsDrivers/releases)
+### Proposed fix
+Add a bounds check in `Keyboard.onKeyEvent()` before indexing the keys array to ignore invalid keycodes and prevent a crash.
+```
+if (keyCode < 0 || keyCode >= keycodeMap.length) {
+            return false;
+}
+```
 
 # Credits and Third-party apps
 
   - **Original Winlator** by [brunodev85](https://github.com/brunodev85/winlator)
   - **Original Winlator Bionic** by [Pipetto-crypto](https://github.com/Pipetto-crypto/winlator)
   - **Winlator (coffincolors fork)** by [coffincolors](https://github.com/coffincolors/winlator)
+  - **Winlator Ludashi** by [StevenMX](https://github.com/StevenMXZ/Winlator-Ludashi)
   - Ubuntu RootFs (Bionic Beaver): [releases.ubuntu.com/bionic](https://www.google.com/search?q=https://releases.ubuntu.com/bionic)
   - Wine: [winehq.org](https://www.winehq.org/)
   - Box86/Box64 by [ptitseb](https://github.com/ptitSeb)
@@ -70,8 +51,6 @@ Many thanks to [ptitseb](https://github.com/ptitSeb) (Box86/Box64), [Danylo](htt
 
 Thank you to
 all the people who believe in this project.
-
-
 
 
 

--- a/app/src/main/java/com/winlator/cmod/xserver/Keyboard.java
+++ b/app/src/main/java/com/winlator/cmod/xserver/Keyboard.java
@@ -99,6 +99,11 @@ public class Keyboard {
         int action = event.getAction();
         int keyCode = event.getKeyCode();
 
+        // Patches: Crash on Asus Rog Phone 9 Pro with Game Genie active (This line should be deleted after the merge)
+        if (keyCode < 0 || keyCode >= keycodeMap.length) {
+            return false; // Ignore unmapped key codes
+        }
+
         if (keyCode == KeyEvent.KEYCODE_TAB || keyCode == KeyEvent.KEYCODE_ESCAPE) {
             if (action == KeyEvent.ACTION_DOWN) {
                 xServer.injectKeyPress(keycodeMap[keyCode]);
@@ -365,4 +370,5 @@ public class Keyboard {
     public static boolean isModifierSticky(byte keycode) {
         return keycode == XKeycode.KEY_CAPS_LOCK.id || keycode == XKeycode.KEY_NUM_LOCK.id;
     }
+
 }


### PR DESCRIPTION
Added a check to ignore unmapped key codes in onKeyEvent method to prevent crashes.

Game Genie (on Asus devices) may send invalid keycodes such as `851` or `861` during screen on/off events. This caused `Keyboard.onKeyEvent()` to index `keys[keyCode]` out of bounds (`length=159, index=851`), leading to `ArrayIndexOutOfBoundsException`.

Tested on Asus ROG Phone 9 Pro with Game Genie active; crash no longer occurs.

### Exception details
Extracted from a logcat generated with adb:
```
FATAL EXCEPTION: main
Process: com.winlator
java.lang.ArrayIndexOutOfBoundsException: length=159 index=851
    at com.winlator.xserver.Keyboard.onKeyEvent(Keyboard.java:104)
Caused by: android.view.KeyEvent-JNI: java.lang.IllegalArgumentException: Invalid keycode 851
```