### PR TITLE
Fix: stick and d-pad freeze multi touch

### DIFF
--- a/app/src/main/java/com/winlator/cmod/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/cmod/widget/InputControlsView.java
@@ -598,10 +598,11 @@ public class InputControlsView extends View {
                     for (byte i = 0, count = (byte)event.getPointerCount(); i < count; i++) {
                         float x = event.getX(i);
                         float y = event.getY(i);
+                        int pid = event.getPointerId(i);
 
                         handled = false;
                         for (ControlElement element : profile.getElements()) {
-                            if (element.handleTouchMove(i, x, y)) handled = true;
+                            if (element.handleTouchMove(pid, x, y)) handled = true;
                         }
                         if (!handled) touchpadView.onTouchEvent(event);
                     }


### PR DESCRIPTION
## Problem
When the joystick or d-pad was touched after another control element (e.g. a button), its pointer ID differed from its loop index in subsequent ACTION_MOVE events. As a result, handleTouchMove() silently skipped all position updates, freezing the stick/d-pad at its last position until the finger was lifted.

## Root cause
In InputControlsView.java, ACTION_MOVE iterates pointers by index `i` and passes `i` as the pointerId to handleTouchMove(). But currentPointerId was stored using the real pointer ID from event.getPointerId(actionIndex). These two values diverge as soon as fingers are added/removed in any order.

## Fix
Pass event.getPointerId(i) instead of raw index i in the ACTION_MOVE loop.

## How to reproduce
1. Press and hold any button
2. Press and drag the stick/d-pad with a second finger
3. Release the button while still holding the stick → Stick/d-pad freezes until finger is lifted