### PR TITLE
feat(renderer): Add AHardwareBuffer pool with property-based testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,36 @@ app/src/main/assets/imagefs.txz
 app/src/main/assets/proton-9.0-arm64ec.txz
 app/src/main/assets/proton-9.0-x86_64.txz
 
+# Android build outputs
+app/build/
+**/build/
+*.apk
+*.aab
+*.ap_
+*.dex
+
+# Gradle caches and wrapper
+.gradle/
+gradle/wrapper/gradle-wrapper.jar
+gradle-app.setting
+!gradle-wrapper.jar
+
+# NDK / CMake
+.cxx/
+*.so
+*.o
+*.a
+
+# IntelliJ / Android Studio
+*.iml
+.idea/
+*.ipr
+*.iws
+out/
+
+# jqwik failure database
+.jqwik-database
+
+# Kiro AI assistant files
+.kiro/
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -129,6 +129,16 @@ android {
             useLegacyPackaging = true
         }
     }
+
+    // Configure JVM unit tests to use JUnit Platform (required by jqwik)
+    testOptions {
+        unitTests {
+            returnDefaultValues = true
+            all {
+                useJUnitPlatform()
+            }
+        }
+    }
 }
 
 dependencies {
@@ -155,6 +165,14 @@ dependencies {
     implementation 'com.kohlschutter.junixsocket:junixsocket-common:2.6.0'
     implementation 'com.kohlschutter.junixsocket:junixsocket-native-common:2.6.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
+
+    // ── Unit-test dependencies ────────────────────────────────────────────
+    // JUnit 4 runner (required by jqwik on Android Gradle projects)
+    testImplementation 'junit:junit:4.13.2'
+    // jqwik property-based testing engine
+    testImplementation 'net.jqwik:jqwik:1.8.4'
+    // jqwik requires the JUnit Platform launcher on the test classpath
+    testImplementation 'org.junit.platform:junit-platform-launcher:1.10.2'
 }
 
 

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(winlator SHARED
         xr/renderer.c
         winlator/drawable.c
         winlator/gpu_image.c
+        winlator/ahb_bridge.c
         winlator/sysvshared_memory.c
         winlator/xconnector_epoll.c
         winlator/alsa_client.c
@@ -35,6 +36,7 @@ target_link_libraries(winlator
         GLESv2
         GLESv3
         adrenotools
+        sync
 )
 
 add_library(fakeinput SHARED

--- a/app/src/main/cpp/winlator/ahb_bridge.c
+++ b/app/src/main/cpp/winlator/ahb_bridge.c
@@ -1,0 +1,165 @@
+/*
+ * ahb_bridge.c — JNI bridge for AHardwareBuffer operations used by AHardwareBufferPool.
+ *
+ * Compiled into libwinlator.so. Provides five JNI functions:
+ *   nativeCreateBuffer            — allocate an AHardwareBuffer
+ *   nativeDestroyBuffer           — release an AHardwareBuffer
+ *   nativeSendBufferToSocket      — send an AHB handle over a Unix socket
+ *   nativeReceiveBufferFromSocket — receive an AHB handle from a Unix socket
+ *   nativeWaitFence               — wait on a sync fence fd, then close it
+ *
+ * All functions return sentinel values (0 for pointers, -1 for fds/status) on
+ * failure and log with tag "AHB_Bridge".
+ */
+
+#include <android/hardware_buffer.h>
+#include <android/log.h>
+#include <jni.h>
+#include <sync/sync.h>
+#include <unistd.h>
+
+#define LOG_TAG "AHB_Bridge"
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+#define LOGW(...) __android_log_print(ANDROID_LOG_WARN,  LOG_TAG, __VA_ARGS__)
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO,  LOG_TAG, __VA_ARGS__)
+
+/* ---------------------------------------------------------------------------
+ * nativeCreateBuffer
+ *
+ * Allocates an AHardwareBuffer with the given dimensions, format, and usage.
+ * Returns the opaque pointer cast to jlong, or 0 on failure.
+ * --------------------------------------------------------------------------- */
+JNIEXPORT jlong JNICALL
+Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeCreateBuffer(
+        JNIEnv *env, jclass cls,
+        jint width, jint height, jint format, jlong usage)
+{
+    (void)env; (void)cls;
+
+    AHardwareBuffer_Desc desc = {
+        .width  = (uint32_t)width,
+        .height = (uint32_t)height,
+        .layers = 1,
+        .format = (uint32_t)format,
+        .usage  = (uint64_t)usage,
+        .stride = 0,  /* filled in by allocate */
+        .rfu0   = 0,
+        .rfu1   = 0,
+    };
+
+    AHardwareBuffer *ahb = NULL;
+    int ret = AHardwareBuffer_allocate(&desc, &ahb);
+    if (ret != 0 || ahb == NULL) {
+        LOGE("nativeCreateBuffer: AHardwareBuffer_allocate failed (ret=%d, w=%d, h=%d, fmt=%d)",
+             ret, width, height, format);
+        return 0;
+    }
+
+    return (jlong)(uintptr_t)ahb;
+}
+
+/* ---------------------------------------------------------------------------
+ * nativeDestroyBuffer
+ *
+ * Releases the AHardwareBuffer at the given pointer.
+ * --------------------------------------------------------------------------- */
+JNIEXPORT void JNICALL
+Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeDestroyBuffer(
+        JNIEnv *env, jclass cls, jlong ptr)
+{
+    (void)env; (void)cls;
+
+    if (ptr == 0) {
+        LOGW("nativeDestroyBuffer: called with null pointer, ignoring");
+        return;
+    }
+
+    AHardwareBuffer *ahb = (AHardwareBuffer *)(uintptr_t)ptr;
+    AHardwareBuffer_release(ahb);
+}
+
+/* ---------------------------------------------------------------------------
+ * nativeSendBufferToSocket
+ *
+ * Sends the AHardwareBuffer handle to a Unix socket fd using
+ * AHardwareBuffer_sendHandleToUnixSocket.
+ * Returns 0 on success, -1 on failure.
+ * --------------------------------------------------------------------------- */
+JNIEXPORT jint JNICALL
+Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeSendBufferToSocket(
+        JNIEnv *env, jclass cls, jlong ptr, jint fd)
+{
+    (void)env; (void)cls;
+
+    if (ptr == 0) {
+        LOGE("nativeSendBufferToSocket: null buffer pointer");
+        return -1;
+    }
+
+    AHardwareBuffer *ahb = (AHardwareBuffer *)(uintptr_t)ptr;
+    int ret = AHardwareBuffer_sendHandleToUnixSocket(ahb, (int)fd);
+    if (ret != 0) {
+        LOGE("nativeSendBufferToSocket: AHardwareBuffer_sendHandleToUnixSocket failed (ret=%d, fd=%d)",
+             ret, fd);
+        return -1;
+    }
+
+    return 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * nativeReceiveBufferFromSocket
+ *
+ * Receives an AHardwareBuffer handle from a Unix socket fd using
+ * AHardwareBuffer_recvHandleFromUnixSocket.
+ * Returns the pointer as jlong, or 0 on failure.
+ * --------------------------------------------------------------------------- */
+JNIEXPORT jlong JNICALL
+Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeReceiveBufferFromSocket(
+        JNIEnv *env, jclass cls, jint fd)
+{
+    (void)env; (void)cls;
+
+    AHardwareBuffer *ahb = NULL;
+    int ret = AHardwareBuffer_recvHandleFromUnixSocket((int)fd, &ahb);
+    if (ret != 0 || ahb == NULL) {
+        LOGE("nativeReceiveBufferFromSocket: AHardwareBuffer_recvHandleFromUnixSocket failed (ret=%d, fd=%d)",
+             ret, fd);
+        return 0;
+    }
+
+    /* Caller owns a reference; bump the refcount so it survives the socket message. */
+    AHardwareBuffer_acquire(ahb);
+    return (jlong)(uintptr_t)ahb;
+}
+
+/* ---------------------------------------------------------------------------
+ * nativeWaitFence
+ *
+ * Waits for the sync fence fd to signal, with a timeout of timeoutMs
+ * milliseconds. Closes fd regardless of outcome (success, timeout, or error).
+ * Returns 0 on success, -1 on timeout or error.
+ * --------------------------------------------------------------------------- */
+JNIEXPORT jint JNICALL
+Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeWaitFence(
+        JNIEnv *env, jclass cls, jint fd, jint timeoutMs)
+{
+    (void)env; (void)cls;
+
+    if (fd < 0) {
+        /* No fence to wait on — treat as already signalled. */
+        return 0;
+    }
+
+    int ret = sync_wait((int)fd, (int)timeoutMs);
+    /* Close fd regardless of outcome, as documented. */
+    close((int)fd);
+
+    if (ret < 0) {
+        LOGE("nativeWaitFence: sync_wait failed or timed out (fd=%d, timeoutMs=%d, errno=%d)",
+             fd, timeoutMs, ret);
+        return -1;
+    }
+
+    return 0;
+}

--- a/app/src/main/java/com/winlator/cmod/renderer/AHardwareBufferPool.java
+++ b/app/src/main/java/com/winlator/cmod/renderer/AHardwareBufferPool.java
@@ -1,0 +1,424 @@
+package com.winlator.cmod.renderer;
+
+import android.util.Log;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Package-private interface that abstracts the five native JNI calls.
+ * The default implementation delegates to the real {@code private static native} methods.
+ * Tests can supply a fake implementation to avoid loading {@code libwinlator.so}.
+ */
+interface AHardwareBufferNativeCalls {
+    long createBuffer(int width, int height, int format, long usage);
+    void destroyBuffer(long ptr);
+    int  sendBufferToSocket(long ptr, int fd);
+    long receiveBufferFromSocket(int fd);
+    int  waitFence(int fd, int timeoutMs);
+}
+
+/**
+ * Manages a fixed pool of pre-allocated AHardwareBuffer objects for use as
+ * swapchain images on the direct Android compositing path.
+ *
+ * <p>Provides acquire/release semantics with fence-based availability tracking.
+ * Buffers are allocated at {@link #init()} time and released at {@link #destroy()}.
+ *
+ * <p>Thread-safety: {@link #acquire()} and {@link #release(int, int)} are safe to
+ * call from any thread. {@link #init()} and {@link #destroy()} must not be called
+ * concurrently with each other or with acquire/release.
+ */
+public class AHardwareBufferPool {
+
+    /**
+     * Default implementation that delegates to the real JNI native methods.
+     * Package-private so tests can supply a fake without modifying this class.
+     */
+    static final AHardwareBufferNativeCalls DEFAULT_NATIVE_CALLS =
+            new AHardwareBufferNativeCalls() {
+        @Override public long createBuffer(int w, int h, int fmt, long usage) {
+            return nativeCreateBuffer(w, h, fmt, usage);
+        }
+        @Override public void destroyBuffer(long ptr) {
+            nativeDestroyBuffer(ptr);
+        }
+        @Override public int sendBufferToSocket(long ptr, int fd) {
+            return nativeSendBufferToSocket(ptr, fd);
+        }
+        @Override public long receiveBufferFromSocket(int fd) {
+            return nativeReceiveBufferFromSocket(fd);
+        }
+        @Override public int waitFence(int fd, int timeoutMs) {
+            return nativeWaitFence(fd, timeoutMs);
+        }
+    };
+
+    /** The native calls provider; replaced in tests via the package-private constructor. */
+    private final AHardwareBufferNativeCalls nativeCalls;
+
+    private static final String LOG_TAG = "AHB_Pool";
+
+    /**
+     * One frame period at 60 Hz — the maximum time {@link #acquire()} will block
+     * before giving up and returning -1.
+     */
+    static final long ACQUIRE_TIMEOUT_MS = 16L;
+
+    // -------------------------------------------------------------------------
+    // Configuration (immutable after construction)
+    // -------------------------------------------------------------------------
+
+    /** Number of buffers in the pool. */
+    private final int count;
+
+    /** Buffer width in pixels. */
+    private final int width;
+
+    /** Buffer height in pixels. */
+    private final int height;
+
+    /**
+     * AHardwareBuffer pixel format.
+     * Default: AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM = 1
+     */
+    private final int format;
+
+    /**
+     * AHardwareBuffer usage flags.
+     * Default: GPU_FRAMEBUFFER | GPU_SAMPLED_IMAGE | COMPOSER_OVERLAY
+     */
+    private final long usage;
+
+    // -------------------------------------------------------------------------
+    // Buffer state (guarded by {@link #lock})
+    // -------------------------------------------------------------------------
+
+    /** AHardwareBuffer* pointers stored as jlong; 0 means unallocated. */
+    private final long[] bufferPtrs;
+
+    /**
+     * Pending release fence fd per slot. -1 means no fence is pending.
+     * Stored here so {@link #destroy()} can close any leaked fds.
+     */
+    private final int[] releaseFds;
+
+    /**
+     * true = slot is currently held by the caller (Wine WSI or SurfaceFlinger).
+     * false = slot is available for {@link #acquire()}.
+     */
+    private final boolean[] inFlight;
+
+    // -------------------------------------------------------------------------
+    // Synchronization
+    // -------------------------------------------------------------------------
+
+    /** Monitor used for acquire/release coordination. */
+    private final Object lock = new Object();
+
+    // -------------------------------------------------------------------------
+    // Observability
+    // -------------------------------------------------------------------------
+
+    /**
+     * Number of consecutive {@link #acquire()} calls that timed out without
+     * obtaining a buffer. Reset to 0 on the next successful acquire.
+     */
+    private int consecutiveDrops = 0;
+
+    // -------------------------------------------------------------------------
+    // Background fence-wait executor
+    // -------------------------------------------------------------------------
+
+    /**
+     * Cached thread pool used to wait on release fences without blocking the
+     * Wine presentation thread.
+     */
+    private final ExecutorService fenceWaiter = Executors.newCachedThreadPool(r -> {
+        Thread t = new Thread(r, "AHB-FenceWaiter");
+        t.setDaemon(true);
+        return t;
+    });
+
+    // -------------------------------------------------------------------------
+    // Static initialiser — load libwinlator.so which contains ahb_bridge.c
+    // -------------------------------------------------------------------------
+
+    static {
+        try {
+            System.loadLibrary("winlator");
+        } catch (UnsatisfiedLinkError e) {
+            // Expected in JVM unit-test environments where the native library
+            // is not available. Tests must supply a fake AHardwareBufferNativeCalls
+            // via the package-private constructor; using DEFAULT_NATIVE_CALLS in
+            // a test environment will throw at call time.
+        }
+    }
+
+    // =========================================================================
+    // Constructors
+    // =========================================================================
+
+    /**
+     * Creates a pool with the given parameters.
+     *
+     * @param width  buffer width in pixels
+     * @param height buffer height in pixels
+     * @param count  number of buffers to pre-allocate (typically 2 or 3)
+     * @param format AHardwareBuffer format constant (e.g. AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM = 1)
+     * @param usage  AHardwareBuffer usage flags
+     */
+    public AHardwareBufferPool(int width, int height, int count, int format, long usage) {
+        this(width, height, count, format, usage, DEFAULT_NATIVE_CALLS);
+    }
+
+    /**
+     * Package-private constructor that accepts a custom {@link AHardwareBufferNativeCalls}
+     * implementation. Used by unit tests to inject a fake without loading the native library.
+     */
+    AHardwareBufferPool(int width, int height, int count, int format, long usage,
+                        AHardwareBufferNativeCalls nativeCalls) {
+        this.width  = width;
+        this.height = height;
+        this.count  = count;
+        this.format = format;
+        this.usage  = usage;
+        this.nativeCalls = nativeCalls;
+
+        bufferPtrs = new long[count];
+        releaseFds = new int[count];
+        inFlight   = new boolean[count];
+
+        for (int i = 0; i < count; i++) {
+            bufferPtrs[i] = 0L;
+            releaseFds[i] = -1;
+            inFlight[i]   = false;
+        }
+    }
+
+    /**
+     * Convenience constructor using the default format and usage flags required
+     * by the direct compositing path.
+     *
+     * <p>Format: {@code AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM} (1)<br>
+     * Usage: {@code GPU_FRAMEBUFFER | GPU_SAMPLED_IMAGE | COMPOSER_OVERLAY}
+     * (0x130 = 0x100 | 0x20 | 0x10)
+     */
+    public AHardwareBufferPool(int width, int height, int count) {
+        this(width, height, count,
+             /* AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM */ 1,
+             /* GPU_FRAMEBUFFER | GPU_SAMPLED_IMAGE | COMPOSER_OVERLAY */
+             0x130L);
+    }
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    /**
+     * Allocates all {@code count} AHardwareBuffers.
+     *
+     * <p>If any allocation fails, all previously allocated buffers are released
+     * and this method returns {@code false}.
+     *
+     * @return {@code true} if all buffers were allocated successfully
+     */
+    public boolean init() {
+        for (int i = 0; i < count; i++) {
+            long ptr = nativeCalls.createBuffer(width, height, format, usage);
+            if (ptr == 0L) {
+                Log.e(LOG_TAG, "init: nativeCreateBuffer failed at slot " + i
+                        + " (w=" + width + ", h=" + height + ", fmt=" + format + ")");
+                // Release all buffers allocated so far
+                for (int j = 0; j < i; j++) {
+                    if (bufferPtrs[j] != 0L) {
+                        nativeCalls.destroyBuffer(bufferPtrs[j]);
+                        bufferPtrs[j] = 0L;
+                    }
+                }
+                return false;
+            }
+            bufferPtrs[i] = ptr;
+        }
+        Log.i(LOG_TAG, "init: allocated " + count + " buffers ("
+                + width + "x" + height + ", fmt=" + format + ")");
+        return true;
+    }
+
+    /**
+     * Returns the index of the next available buffer slot, blocking up to
+     * {@link #ACQUIRE_TIMEOUT_MS} milliseconds if all slots are in-flight.
+     *
+     * <p>Returns -1 if no buffer becomes available within the timeout.
+     */
+    public int acquire() {
+        synchronized (lock) {
+            long deadline = System.currentTimeMillis() + ACQUIRE_TIMEOUT_MS;
+
+            while (true) {
+                // Fast path: scan for a free slot
+                for (int i = 0; i < count; i++) {
+                    if (!inFlight[i]) {
+                        inFlight[i] = true;
+                        consecutiveDrops = 0;
+                        return i;
+                    }
+                }
+
+                // All slots in-flight — wait for a release notification
+                long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    break;
+                }
+                try {
+                    lock.wait(remaining);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+
+            // Timeout — log and return sentinel
+            consecutiveDrops++;
+            Log.w(LOG_TAG, "acquire: timeout after " + ACQUIRE_TIMEOUT_MS
+                    + " ms, consecutiveDrops=" + consecutiveDrops);
+            return -1;
+        }
+    }
+
+    /**
+     * Returns the AHardwareBuffer pointer for the given slot index.
+     *
+     * <p>Only valid while the slot is acquired (between {@link #acquire()} and
+     * the corresponding {@link #release(int, int)}).
+     *
+     * @param index slot index returned by {@link #acquire()}
+     * @return AHardwareBuffer* as a {@code long}
+     */
+    public long getBufferPtr(int index) {
+        return bufferPtrs[index];
+    }
+
+    /** Returns the number of buffers in the pool. */
+    public int getCount() {
+        return count;
+    }
+
+    /** Returns the buffer width in pixels. */
+    public int getWidth() {
+        return width;
+    }
+
+    /** Returns the buffer height in pixels. */
+    public int getHeight() {
+        return height;
+    }
+
+    /** Returns the AHardwareBuffer format constant. */
+    public int getFormat() {
+        return format;
+    }
+
+    /** Returns the AHardwareBuffer usage flags. */
+    public long getUsage() {
+        return usage;
+    }
+
+    /**
+     * Marks the buffer at {@code index} as available for reuse once
+     * {@code releaseFenceFd} signals.
+     *
+     * <p>If {@code releaseFenceFd == -1} the buffer is immediately available and
+     * waiting threads are notified inline. If {@code releaseFenceFd >= 0} a
+     * background thread waits on the fence (via {@link #nativeWaitFence}) and
+     * then notifies waiting threads. Ownership of {@code releaseFenceFd}
+     * transfers to this pool; it will be closed after use.
+     *
+     * @param index          slot index previously returned by {@link #acquire()}
+     * @param releaseFenceFd sync fence fd, or -1 if the buffer is already free
+     */
+    public void release(int index, int releaseFenceFd) {
+        if (index < 0 || index >= count) {
+            Log.e(LOG_TAG, "release: invalid index " + index);
+            if (releaseFenceFd >= 0) {
+                nativeCalls.waitFence(releaseFenceFd, 0);
+            }
+            return;
+        }
+
+        if (releaseFenceFd == -1) {
+            // No fence — mark available immediately
+            synchronized (lock) {
+                inFlight[index]   = false;
+                releaseFds[index] = -1;
+                lock.notifyAll();
+            }
+        } else {
+            // Fence present — wait on a background thread, then notify
+            final int slotIndex = index;
+            final int fenceFd   = releaseFenceFd;
+            fenceWaiter.submit(() -> {
+                // nativeWaitFence closes fenceFd regardless of outcome
+                nativeCalls.waitFence(fenceFd, (int) ACQUIRE_TIMEOUT_MS);
+                synchronized (lock) {
+                    inFlight[slotIndex]   = false;
+                    releaseFds[slotIndex] = -1;
+                    lock.notifyAll();
+                }
+            });
+        }
+    }
+
+    /**
+     * Destroys all buffers and shuts down the fence-waiter thread pool.
+     *
+     * <p>Must be called after all in-flight buffers have been released (i.e.,
+     * all release fences have signalled). Any remaining pending fences are
+     * closed immediately without waiting.
+     */
+    public void destroy() {
+        fenceWaiter.shutdownNow();
+
+        synchronized (lock) {
+            for (int i = 0; i < count; i++) {
+                if (releaseFds[i] >= 0) {
+                    nativeCalls.waitFence(releaseFds[i], 0);
+                    releaseFds[i] = -1;
+                }
+                if (bufferPtrs[i] != 0L) {
+                    nativeCalls.destroyBuffer(bufferPtrs[i]);
+                    bufferPtrs[i] = 0L;
+                }
+                inFlight[i] = false;
+            }
+            lock.notifyAll();
+        }
+
+        Log.i(LOG_TAG, "destroy: all buffers released");
+    }
+
+    // =========================================================================
+    // Native methods — implemented in ahb_bridge.c (libwinlator.so)
+    // =========================================================================
+
+    /** @return AHardwareBuffer* as jlong, or 0 on failure */
+    private static native long nativeCreateBuffer(int width, int height, int format, long usage);
+
+    /** Releases the AHardwareBuffer at {@code ptr}. */
+    private static native void nativeDestroyBuffer(long ptr);
+
+    /** @return 0 on success, -1 on failure */
+    private static native int nativeSendBufferToSocket(long ptr, int fd);
+
+    /** @return AHardwareBuffer* as jlong, or 0 on failure */
+    private static native long nativeReceiveBufferFromSocket(int fd);
+
+    /**
+     * Waits for the sync fence fd to signal, then closes it.
+     *
+     * @param fd        sync fence file descriptor
+     * @param timeoutMs maximum wait time in milliseconds
+     * @return 0 on success, -1 on timeout or error
+     */
+    private static native int nativeWaitFence(int fd, int timeoutMs);
+}

--- a/app/src/test/java/com/winlator/cmod/renderer/AHardwareBufferPoolInitFailureTest.java
+++ b/app/src/test/java/com/winlator/cmod/renderer/AHardwareBufferPoolInitFailureTest.java
@@ -1,0 +1,188 @@
+package com.winlator.cmod.renderer;
+
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Unit tests for pool initialization failure handling.
+ *
+ * <p>For each k in 0..N-1:
+ * <ul>
+ *   <li>Mock {@code nativeCreateBuffer} to succeed for calls 0..k-1 and fail
+ *       (return 0) on call k.</li>
+ *   <li>Assert {@code init()} returns {@code false}.</li>
+ *   <li>Assert {@code nativeDestroyBuffer} was called exactly k times (once for
+ *       each successfully allocated buffer).</li>
+ *   <li>Assert {@code nativeDestroyBuffer} was NOT called with 0 (the failure
+ *       sentinel).</li>
+ * </ul>
+ */
+public class AHardwareBufferPoolInitFailureTest {
+
+    private static final long PTR_BASE = 1000L;
+
+    /**
+     * Fake {@link AHardwareBufferNativeCalls} that:
+     * <ul>
+     *   <li>Returns unique non-zero pointers for calls 0..failAtIndex-1.</li>
+     *   <li>Returns 0 (failure sentinel) on call number failAtIndex.</li>
+     *   <li>Records all pointers passed to {@code destroyBuffer}.</li>
+     * </ul>
+     */
+    private static class FailAtKNativeCalls implements AHardwareBufferNativeCalls {
+        private final int failAtIndex;
+        private final AtomicInteger createCallCount = new AtomicInteger(0);
+        private final AtomicLong ptrCounter = new AtomicLong(PTR_BASE);
+        final List<Long> destroyedPtrs = new ArrayList<>();
+        final List<Long> allocatedPtrs = new ArrayList<>();
+
+        FailAtKNativeCalls(int failAtIndex) {
+            this.failAtIndex = failAtIndex;
+        }
+
+        @Override
+        public long createBuffer(int width, int height, int format, long usage) {
+            int callIndex = createCallCount.getAndIncrement();
+            if (callIndex == failAtIndex) {
+                return 0L;
+            }
+            long ptr = ptrCounter.getAndIncrement();
+            allocatedPtrs.add(ptr);
+            return ptr;
+        }
+
+        @Override
+        public synchronized void destroyBuffer(long ptr) {
+            destroyedPtrs.add(ptr);
+        }
+
+        @Override
+        public int sendBufferToSocket(long ptr, int fd) {
+            return 0;
+        }
+
+        @Override
+        public long receiveBufferFromSocket(int fd) {
+            return ptrCounter.getAndIncrement();
+        }
+
+        @Override
+        public int waitFence(int fd, int timeoutMs) {
+            return 0;
+        }
+    }
+
+    /**
+     * Runs the failure-at-k scenario for a pool of size {@code poolSize} where
+     * {@code nativeCreateBuffer} fails at call index {@code failAtIndex}.
+     *
+     * <p>Verifies:
+     * <ol>
+     *   <li>{@code init()} returns {@code false}.</li>
+     *   <li>{@code nativeDestroyBuffer} is called exactly {@code failAtIndex} times.</li>
+     *   <li>Each of the {@code failAtIndex} successfully allocated pointers was destroyed.</li>
+     *   <li>{@code nativeDestroyBuffer} was NOT called with 0 (the failure sentinel).</li>
+     * </ol>
+     */
+    private static void assertInitFailureAtK(int poolSize, int failAtIndex) {
+        FailAtKNativeCalls fake = new FailAtKNativeCalls(failAtIndex);
+
+        AHardwareBufferPool pool = new AHardwareBufferPool(
+                64, 64, poolSize,
+                /* AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM */ 1,
+                /* GPU_FRAMEBUFFER | GPU_SAMPLED_IMAGE | COMPOSER_OVERLAY */ 0x130L,
+                fake);
+
+        boolean result = pool.init();
+        if (result) {
+            throw new AssertionError(
+                    "init() must return false when nativeCreateBuffer fails at index "
+                            + failAtIndex + " (poolSize=" + poolSize + ")");
+        }
+
+        int expectedDestroyCount = failAtIndex;
+        if (fake.destroyedPtrs.size() != expectedDestroyCount) {
+            throw new AssertionError(
+                    "nativeDestroyBuffer must be called exactly " + expectedDestroyCount
+                            + " time(s) when failure occurs at index " + failAtIndex
+                            + " (poolSize=" + poolSize + "), but was called "
+                            + fake.destroyedPtrs.size() + " time(s)");
+        }
+
+        for (int i = 0; i < fake.allocatedPtrs.size(); i++) {
+            long allocatedPtr = fake.allocatedPtrs.get(i);
+            if (!fake.destroyedPtrs.contains(allocatedPtr)) {
+                throw new AssertionError(
+                        "nativeDestroyBuffer must be called with allocated pointer 0x"
+                                + Long.toHexString(allocatedPtr)
+                                + " (slot " + i + ", poolSize=" + poolSize
+                                + ", failAtIndex=" + failAtIndex + ")");
+            }
+        }
+
+        if (fake.destroyedPtrs.contains(0L)) {
+            throw new AssertionError(
+                    "nativeDestroyBuffer must NOT be called with 0 (the failure sentinel) "
+                            + "(poolSize=" + poolSize + ", failAtIndex=" + failAtIndex + ")");
+        }
+    }
+
+    @Property(tries = 100)
+    void initFailureAtK_releasesAllPreviousBuffersAndReturnsFalse(
+            @ForAll @IntRange(min = 1, max = 8) int poolSize,
+            @ForAll @IntRange(min = 0, max = 7) int failAtIndexRaw) {
+
+        int failAtIndex = failAtIndexRaw % poolSize;
+        assertInitFailureAtK(poolSize, failAtIndex);
+    }
+
+    /** Pool of 1: failure at k=0 — no buffers allocated, no destroys expected. */
+    @Property(tries = 1)
+    void poolSize1_failureAtK0() { assertInitFailureAtK(1, 0); }
+
+    /** Pool of 2: failure at k=0 — no destroys expected. */
+    @Property(tries = 1)
+    void poolSize2_failureAtK0() { assertInitFailureAtK(2, 0); }
+
+    /** Pool of 2: failure at k=1 — 1 destroy expected. */
+    @Property(tries = 1)
+    void poolSize2_failureAtK1() { assertInitFailureAtK(2, 1); }
+
+    /** Pool of 3: failure at k=0 — no destroys expected. */
+    @Property(tries = 1)
+    void poolSize3_failureAtK0() { assertInitFailureAtK(3, 0); }
+
+    /** Pool of 3: failure at k=1 — 1 destroy expected. */
+    @Property(tries = 1)
+    void poolSize3_failureAtK1() { assertInitFailureAtK(3, 1); }
+
+    /** Pool of 3: failure at k=2 — 2 destroys expected. */
+    @Property(tries = 1)
+    void poolSize3_failureAtK2() { assertInitFailureAtK(3, 2); }
+
+    /** Pool of 4: failure at k=0 — no destroys expected. */
+    @Property(tries = 1)
+    void poolSize4_failureAtK0() { assertInitFailureAtK(4, 0); }
+
+    /** Pool of 4: failure at k=3 — 3 destroys expected. */
+    @Property(tries = 1)
+    void poolSize4_failureAtK3() { assertInitFailureAtK(4, 3); }
+
+    /** Pool of 8: failure at k=0 — no destroys expected. */
+    @Property(tries = 1)
+    void poolSize8_failureAtK0() { assertInitFailureAtK(8, 0); }
+
+    /** Pool of 8: failure at k=4 — 4 destroys expected. */
+    @Property(tries = 1)
+    void poolSize8_failureAtK4() { assertInitFailureAtK(8, 4); }
+
+    /** Pool of 8: failure at k=7 — 7 destroys expected. */
+    @Property(tries = 1)
+    void poolSize8_failureAtK7() { assertInitFailureAtK(8, 7); }
+}

--- a/app/src/test/java/com/winlator/cmod/renderer/AHardwareBufferPoolProperty15Test.java
+++ b/app/src/test/java/com/winlator/cmod/renderer/AHardwareBufferPoolProperty15Test.java
@@ -1,0 +1,204 @@
+package com.winlator.cmod.renderer;
+
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Drop Warning Includes Consecutive Count
+ *
+ * For any N in [1..10] consecutive timeouts:
+ *   - After N calls to {@code acquire()} that all time out (all slots in-flight),
+ *     the {@code consecutiveDrops} counter equals N.
+ *   - The warning log message format is
+ *     {@code "acquire: timeout after <TIMEOUT> ms, consecutiveDrops=<N>"},
+ *     which contains the value N.
+ *   - After a successful acquire, {@code consecutiveDrops} resets to 0.
+ *
+ * <p>Because {@code android.util.Log} is a no-op stub in JVM unit tests
+ * ({@code returnDefaultValues = true}), the log message content is verified
+ * by inspecting the private {@code consecutiveDrops} field via reflection.
+ */
+public class AHardwareBufferPoolProperty15Test {
+
+    private static AHardwareBufferNativeCalls fakeCalls() {
+        final AtomicLong ptrCounter = new AtomicLong(1000L);
+        return new AHardwareBufferNativeCalls() {
+            @Override
+            public long createBuffer(int width, int height, int format, long usage) {
+                return ptrCounter.getAndIncrement();
+            }
+            @Override public void destroyBuffer(long ptr) {}
+            @Override public int  sendBufferToSocket(long ptr, int fd) { return 0; }
+            @Override public long receiveBufferFromSocket(int fd) { return ptrCounter.getAndIncrement(); }
+            @Override public int  waitFence(int fd, int timeoutMs) { return 0; }
+        };
+    }
+
+    private static AHardwareBufferPool makePool(int n) {
+        AHardwareBufferPool pool = new AHardwareBufferPool(
+                64, 64, n,
+                /* AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM */ 1,
+                /* GPU_FRAMEBUFFER | GPU_SAMPLED_IMAGE | COMPOSER_OVERLAY */ 0x130L,
+                fakeCalls());
+        boolean ok = pool.init();
+        if (!ok) {
+            throw new AssertionError("pool.init() must succeed with fake native calls");
+        }
+        return pool;
+    }
+
+    private static int readConsecutiveDrops(AHardwareBufferPool pool) {
+        try {
+            Field f = AHardwareBufferPool.class.getDeclaredField("consecutiveDrops");
+            f.setAccessible(true);
+            return (int) f.get(pool);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new AssertionError("Could not read consecutiveDrops field: " + e.getMessage(), e);
+        }
+    }
+
+    @Property(tries = 100)
+    void afterNConsecutiveTimeoutsDropCountEqualsN(
+            @ForAll @IntRange(min = 1, max = 10) int n) {
+
+        AHardwareBufferPool pool = makePool(1);
+        try {
+            int heldSlot = pool.acquire();
+            if (heldSlot < 0) {
+                throw new AssertionError("Initial acquire() must succeed on a fresh pool");
+            }
+
+            int dropsAfterSuccess = readConsecutiveDrops(pool);
+            if (dropsAfterSuccess != 0) {
+                throw new AssertionError(
+                        "consecutiveDrops must be 0 after a successful acquire(), got "
+                        + dropsAfterSuccess);
+            }
+
+            for (int i = 1; i <= n; i++) {
+                int result = pool.acquire();
+
+                if (result != -1) {
+                    throw new AssertionError(
+                            "acquire() must return -1 when pool is exhausted (call " + i
+                            + " of " + n + "), got " + result);
+                }
+
+                int drops = readConsecutiveDrops(pool);
+                if (drops != i) {
+                    throw new AssertionError(
+                            "consecutiveDrops must equal " + i + " after " + i
+                            + " consecutive timeout(s), got " + drops);
+                }
+            }
+
+            int finalDrops = readConsecutiveDrops(pool);
+            if (finalDrops != n) {
+                throw new AssertionError(
+                        "consecutiveDrops must equal N=" + n + " after N consecutive timeouts, "
+                        + "got " + finalDrops);
+            }
+
+            pool.release(heldSlot, -1);
+        } finally {
+            pool.destroy();
+        }
+    }
+
+    @Property(tries = 100)
+    void consecutiveDropsResetsToZeroAfterSuccessfulAcquire(
+            @ForAll @IntRange(min = 1, max = 10) int n) {
+
+        AHardwareBufferPool pool = makePool(1);
+        try {
+            int heldSlot = pool.acquire();
+            if (heldSlot < 0) {
+                throw new AssertionError("Initial acquire() must succeed on a fresh pool");
+            }
+
+            for (int i = 0; i < n; i++) {
+                int result = pool.acquire();
+                if (result != -1) {
+                    throw new AssertionError(
+                            "acquire() must return -1 when pool is exhausted (call " + (i + 1)
+                            + " of " + n + "), got " + result);
+                }
+            }
+
+            int dropsBeforeReset = readConsecutiveDrops(pool);
+            if (dropsBeforeReset != n) {
+                throw new AssertionError(
+                        "consecutiveDrops must equal N=" + n + " after N timeouts, got "
+                        + dropsBeforeReset);
+            }
+
+            pool.release(heldSlot, -1);
+
+            int reacquired = pool.acquire();
+            if (reacquired < 0) {
+                throw new AssertionError(
+                        "acquire() must succeed after releasing the held slot, got " + reacquired);
+            }
+
+            int dropsAfterReset = readConsecutiveDrops(pool);
+            if (dropsAfterReset != 0) {
+                throw new AssertionError(
+                        "consecutiveDrops must reset to 0 after a successful acquire(), "
+                        + "got " + dropsAfterReset
+                        + " (was " + n + " before the successful acquire)");
+            }
+
+            pool.release(reacquired, -1);
+        } finally {
+            pool.destroy();
+        }
+    }
+
+    @Property(tries = 100)
+    void warningLogMessageFormatContainsConsecutiveDropsCount(
+            @ForAll @IntRange(min = 1, max = 10) int n) {
+
+        AHardwareBufferPool pool = makePool(1);
+        try {
+            int heldSlot = pool.acquire();
+            if (heldSlot < 0) {
+                throw new AssertionError("Initial acquire() must succeed on a fresh pool");
+            }
+
+            for (int i = 0; i < n; i++) {
+                int result = pool.acquire();
+                if (result != -1) {
+                    throw new AssertionError(
+                            "acquire() must return -1 when pool is exhausted, got " + result);
+                }
+            }
+
+            int consecutiveDrops = readConsecutiveDrops(pool);
+
+            // Construct the warning message exactly as the production code does
+            String warningMessage = "acquire: timeout after " + AHardwareBufferPool.ACQUIRE_TIMEOUT_MS
+                    + " ms, consecutiveDrops=" + consecutiveDrops;
+
+            String expectedSubstring = "consecutiveDrops=" + n;
+            if (!warningMessage.contains(expectedSubstring)) {
+                throw new AssertionError(
+                        "Warning log message must contain '" + expectedSubstring + "' after N="
+                        + n + " consecutive timeouts, but message was: '" + warningMessage + "'");
+            }
+
+            if (consecutiveDrops != n) {
+                throw new AssertionError(
+                        "consecutiveDrops must equal N=" + n + " after N consecutive timeouts, "
+                        + "got " + consecutiveDrops);
+            }
+
+            pool.release(heldSlot, -1);
+        } finally {
+            pool.destroy();
+        }
+    }
+}

--- a/app/src/test/java/com/winlator/cmod/renderer/AHardwareBufferPoolProperty1Test.java
+++ b/app/src/test/java/com/winlator/cmod/renderer/AHardwareBufferPoolProperty1Test.java
@@ -1,0 +1,205 @@
+package com.winlator.cmod.renderer;
+
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Pool Initialization Correctness
+ *
+ * For any valid pool configuration (count N in [1..8], width W in [64..4096],
+ * height H in [64..4096]), after {@code pool.init()} succeeds:
+ *   - {@code pool.getCount()} == N
+ *   - each buffer pointer is non-zero
+ *   - {@code pool.getFormat()} == AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM (1)
+ *   - {@code pool.getUsage()} includes GPU_FRAMEBUFFER | GPU_SAMPLED_IMAGE | COMPOSER_OVERLAY
+ *   - {@code pool.getWidth()} == W and {@code pool.getHeight()} == H
+ *   - {@code init()} returns {@code true}
+ */
+public class AHardwareBufferPoolProperty1Test {
+
+    /** AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM = 1 (from NDK android/hardware_buffer.h) */
+    private static final int AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM = 1;
+
+    /**
+     * Required usage flags for the direct compositing path.
+     * AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER   = 0x100
+     * AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE = 0x020
+     * AHARDWAREBUFFER_USAGE_COMPOSER_OVERLAY  = 0x010
+     * Combined: 0x130
+     */
+    private static final long REQUIRED_USAGE_FLAGS = 0x130L;
+
+    private static AHardwareBufferNativeCalls fakeCalls() {
+        final AtomicLong ptrCounter = new AtomicLong(1000L);
+        return new AHardwareBufferNativeCalls() {
+            @Override
+            public long createBuffer(int width, int height, int format, long usage) {
+                return ptrCounter.getAndIncrement();
+            }
+            @Override public void destroyBuffer(long ptr) {}
+            @Override public int  sendBufferToSocket(long ptr, int fd) { return 0; }
+            @Override public long receiveBufferFromSocket(int fd) { return ptrCounter.getAndIncrement(); }
+            @Override public int  waitFence(int fd, int timeoutMs) { return 0; }
+        };
+    }
+
+    @Property(tries = 100)
+    void poolInitCorrectness(
+            @ForAll @IntRange(min = 1, max = 8)     int n,
+            @ForAll @IntRange(min = 64, max = 4096) int w,
+            @ForAll @IntRange(min = 64, max = 4096) int h) {
+
+        AHardwareBufferPool pool = new AHardwareBufferPool(
+                w, h, n,
+                AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM,
+                REQUIRED_USAGE_FLAGS,
+                fakeCalls());
+
+        boolean initResult = pool.init();
+        if (!initResult) {
+            throw new AssertionError(
+                    "init() must return true for valid parameters (n=" + n + ", w=" + w + ", h=" + h + ")");
+        }
+
+        if (pool.getCount() != n) {
+            throw new AssertionError(
+                    "getCount() must equal N=" + n + " after init(), got " + pool.getCount());
+        }
+
+        for (int i = 0; i < n; i++) {
+            int slot = pool.acquire();
+            if (slot == -1) {
+                throw new AssertionError("acquire() must succeed for slot " + i + " after init()");
+            }
+            long ptr = pool.getBufferPtr(slot);
+            if (ptr == 0L) {
+                throw new AssertionError("bufferPtr[" + slot + "] must be non-zero after init()");
+            }
+            pool.release(slot, -1);
+        }
+
+        if (pool.getFormat() != AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM) {
+            throw new AssertionError(
+                    "format must be AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM (1), got " + pool.getFormat());
+        }
+
+        long actualUsage = pool.getUsage();
+        if ((actualUsage & REQUIRED_USAGE_FLAGS) != REQUIRED_USAGE_FLAGS) {
+            throw new AssertionError(
+                    "usage must include 0x130 (GPU_FRAMEBUFFER | GPU_SAMPLED_IMAGE | COMPOSER_OVERLAY), "
+                    + "got 0x" + Long.toHexString(actualUsage));
+        }
+
+        if (pool.getWidth() != w) {
+            throw new AssertionError("getWidth() must equal W=" + w + ", got " + pool.getWidth());
+        }
+        if (pool.getHeight() != h) {
+            throw new AssertionError("getHeight() must equal H=" + h + ", got " + pool.getHeight());
+        }
+
+        pool.destroy();
+    }
+
+    @Property(tries = 100)
+    void poolInit_callsCreateBufferExactlyNTimes(
+            @ForAll @IntRange(min = 1, max = 8)     int n,
+            @ForAll @IntRange(min = 64, max = 4096) int w,
+            @ForAll @IntRange(min = 64, max = 4096) int h) {
+
+        final AtomicLong createCallCount = new AtomicLong(0);
+        final AtomicLong ptrBase = new AtomicLong(1L);
+
+        AHardwareBufferNativeCalls countingCalls = new AHardwareBufferNativeCalls() {
+            @Override
+            public long createBuffer(int width, int height, int format, long usage) {
+                createCallCount.incrementAndGet();
+                return ptrBase.getAndIncrement();
+            }
+            @Override public void destroyBuffer(long ptr) {}
+            @Override public int  sendBufferToSocket(long ptr, int fd) { return 0; }
+            @Override public long receiveBufferFromSocket(int fd) { return ptrBase.getAndIncrement(); }
+            @Override public int  waitFence(int fd, int timeoutMs) { return 0; }
+        };
+
+        AHardwareBufferPool pool = new AHardwareBufferPool(
+                w, h, n,
+                AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM,
+                REQUIRED_USAGE_FLAGS,
+                countingCalls);
+
+        pool.init();
+
+        int actualCalls = (int) createCallCount.get();
+        if (actualCalls != n) {
+            throw new AssertionError(
+                    "init() must call createBuffer exactly N=" + n + " times, called " + actualCalls);
+        }
+
+        pool.destroy();
+    }
+
+    @Property(tries = 100)
+    void poolInit_passesCorrectParametersToCreateBuffer(
+            @ForAll @IntRange(min = 1, max = 8)     int n,
+            @ForAll @IntRange(min = 64, max = 4096) int w,
+            @ForAll @IntRange(min = 64, max = 4096) int h) {
+
+        final int    expectedFormat = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+        final long   expectedUsage  = REQUIRED_USAGE_FLAGS;
+        final AtomicLong ptrBase    = new AtomicLong(1L);
+
+        final int[]  capturedWidth  = new int[n];
+        final int[]  capturedHeight = new int[n];
+        final int[]  capturedFormat = new int[n];
+        final long[] capturedUsage  = new long[n];
+        final int[]  callIndex      = {0};
+
+        AHardwareBufferNativeCalls capturingCalls = new AHardwareBufferNativeCalls() {
+            @Override
+            public long createBuffer(int width, int height, int format, long usage) {
+                int idx = callIndex[0]++;
+                if (idx < n) {
+                    capturedWidth[idx]  = width;
+                    capturedHeight[idx] = height;
+                    capturedFormat[idx] = format;
+                    capturedUsage[idx]  = usage;
+                }
+                return ptrBase.getAndIncrement();
+            }
+            @Override public void destroyBuffer(long ptr) {}
+            @Override public int  sendBufferToSocket(long ptr, int fd) { return 0; }
+            @Override public long receiveBufferFromSocket(int fd) { return ptrBase.getAndIncrement(); }
+            @Override public int  waitFence(int fd, int timeoutMs) { return 0; }
+        };
+
+        AHardwareBufferPool pool = new AHardwareBufferPool(
+                w, h, n, expectedFormat, expectedUsage, capturingCalls);
+        pool.init();
+
+        for (int i = 0; i < n; i++) {
+            if (capturedWidth[i] != w) {
+                throw new AssertionError(
+                        "createBuffer call " + i + " must use width=" + w + ", got " + capturedWidth[i]);
+            }
+            if (capturedHeight[i] != h) {
+                throw new AssertionError(
+                        "createBuffer call " + i + " must use height=" + h + ", got " + capturedHeight[i]);
+            }
+            if (capturedFormat[i] != expectedFormat) {
+                throw new AssertionError(
+                        "createBuffer call " + i + " must use format=" + expectedFormat
+                        + ", got " + capturedFormat[i]);
+            }
+            if (capturedUsage[i] != expectedUsage) {
+                throw new AssertionError(
+                        "createBuffer call " + i + " must use usage=0x" + Long.toHexString(expectedUsage)
+                        + ", got 0x" + Long.toHexString(capturedUsage[i]));
+            }
+        }
+
+        pool.destroy();
+    }
+}

--- a/app/src/test/java/com/winlator/cmod/renderer/AHardwareBufferPoolProperty2Test.java
+++ b/app/src/test/java/com/winlator/cmod/renderer/AHardwareBufferPoolProperty2Test.java
@@ -1,0 +1,211 @@
+package com.winlator.cmod.renderer;
+
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Acquire-Release Round-Trip
+ *
+ * For any pool size N in [1..4] and arbitrary slot sequences:
+ *   - {@code acquire()} returns a non-negative index in [0, N)
+ *   - after {@code release(index, -1)}, the same slot is acquirable again
+ *     within {@link AHardwareBufferPool#ACQUIRE_TIMEOUT_MS}
+ *   - releasing all N slots makes all N slots available again
+ *   - acquire/release cycles are repeatable without degradation
+ */
+public class AHardwareBufferPoolProperty2Test {
+
+    private static AHardwareBufferNativeCalls fakeCalls() {
+        final AtomicLong ptrCounter = new AtomicLong(1000L);
+        return new AHardwareBufferNativeCalls() {
+            @Override
+            public long createBuffer(int width, int height, int format, long usage) {
+                return ptrCounter.getAndIncrement();
+            }
+            @Override public void destroyBuffer(long ptr) {}
+            @Override public int  sendBufferToSocket(long ptr, int fd) { return 0; }
+            @Override public long receiveBufferFromSocket(int fd) { return ptrCounter.getAndIncrement(); }
+            @Override public int  waitFence(int fd, int timeoutMs) { return 0; }
+        };
+    }
+
+    private static AHardwareBufferPool makePool(int n) {
+        AHardwareBufferPool pool = new AHardwareBufferPool(
+                64, 64, n,
+                /* AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM */ 1,
+                /* GPU_FRAMEBUFFER | GPU_SAMPLED_IMAGE | COMPOSER_OVERLAY */ 0x130L,
+                fakeCalls());
+        boolean ok = pool.init();
+        if (!ok) {
+            throw new AssertionError("pool.init() must succeed with fake native calls");
+        }
+        return pool;
+    }
+
+    @Property(tries = 100)
+    void singleAcquireReleaseRoundTrip(
+            @ForAll @IntRange(min = 1, max = 4) int n) {
+
+        AHardwareBufferPool pool = makePool(n);
+        try {
+            int slot = pool.acquire();
+
+            if (slot < 0 || slot >= n) {
+                throw new AssertionError(
+                        "acquire() must return index in [0, " + n + "), got " + slot);
+            }
+
+            pool.release(slot, -1);
+
+            int reacquired = pool.acquire();
+            if (reacquired < 0 || reacquired >= n) {
+                throw new AssertionError(
+                        "re-acquire() after release(fd=-1) must return valid index in [0, " + n
+                        + "), got " + reacquired);
+            }
+
+            if (n == 1 && reacquired != slot) {
+                throw new AssertionError(
+                        "with N=1, re-acquire() must return the same slot=" + slot
+                        + " that was released, got " + reacquired);
+            }
+
+            pool.release(reacquired, -1);
+        } finally {
+            pool.destroy();
+        }
+    }
+
+    @Property(tries = 100)
+    void acquireAllReleasAllReacquireAll(
+            @ForAll @IntRange(min = 1, max = 4) int n) {
+
+        AHardwareBufferPool pool = makePool(n);
+        try {
+            int[] slots = new int[n];
+            for (int i = 0; i < n; i++) {
+                slots[i] = pool.acquire();
+                if (slots[i] < 0 || slots[i] >= n) {
+                    throw new AssertionError(
+                            "acquire() call " + i + " must return index in [0, " + n
+                            + "), got " + slots[i]);
+                }
+            }
+
+            for (int i = 0; i < n; i++) {
+                for (int j = i + 1; j < n; j++) {
+                    if (slots[i] == slots[j]) {
+                        throw new AssertionError(
+                                "acquire() returned duplicate slot " + slots[i]
+                                + " at positions " + i + " and " + j);
+                    }
+                }
+            }
+
+            for (int i = 0; i < n; i++) {
+                pool.release(slots[i], -1);
+            }
+
+            List<Integer> reacquired = new ArrayList<>(n);
+            for (int i = 0; i < n; i++) {
+                int slot = pool.acquire();
+                if (slot < 0 || slot >= n) {
+                    throw new AssertionError(
+                            "re-acquire() call " + i + " after releasing all slots must return "
+                            + "index in [0, " + n + "), got " + slot
+                            + " (only " + i + " of " + n + " slots re-acquired so far)");
+                }
+                reacquired.add(slot);
+            }
+
+            for (int i = 0; i < reacquired.size(); i++) {
+                for (int j = i + 1; j < reacquired.size(); j++) {
+                    if (reacquired.get(i).equals(reacquired.get(j))) {
+                        throw new AssertionError(
+                                "re-acquire() returned duplicate slot " + reacquired.get(i)
+                                + " at positions " + i + " and " + j);
+                    }
+                }
+            }
+
+            for (int slot : reacquired) {
+                pool.release(slot, -1);
+            }
+        } finally {
+            pool.destroy();
+        }
+    }
+
+    @Property(tries = 100)
+    void repeatedCyclesAreStable(
+            @ForAll @IntRange(min = 1, max = 4)  int n,
+            @ForAll @IntRange(min = 1, max = 10) int cycles) {
+
+        AHardwareBufferPool pool = makePool(n);
+        try {
+            for (int cycle = 0; cycle < cycles; cycle++) {
+                int[] slots = new int[n];
+
+                for (int i = 0; i < n; i++) {
+                    slots[i] = pool.acquire();
+                    if (slots[i] < 0 || slots[i] >= n) {
+                        throw new AssertionError(
+                                "cycle " + cycle + ": acquire() call " + i
+                                + " must return index in [0, " + n + "), got " + slots[i]);
+                    }
+                }
+
+                for (int i = 0; i < n; i++) {
+                    pool.release(slots[i], -1);
+                }
+            }
+        } finally {
+            pool.destroy();
+        }
+    }
+
+    @Property(tries = 100)
+    void partialReleaseMakesExactlyOneSlotAvailable(
+            @ForAll @IntRange(min = 2, max = 4) int n,
+            @ForAll @IntRange(min = 0, max = 3) int releasePos) {
+
+        int rPos = releasePos % n;
+
+        AHardwareBufferPool pool = makePool(n);
+        try {
+            int[] slots = new int[n];
+            for (int i = 0; i < n; i++) {
+                slots[i] = pool.acquire();
+                if (slots[i] < 0 || slots[i] >= n) {
+                    throw new AssertionError(
+                            "acquire() call " + i + " must return index in [0, " + n
+                            + "), got " + slots[i]);
+                }
+            }
+
+            int releasedSlot = slots[rPos];
+            pool.release(releasedSlot, -1);
+
+            int reacquired = pool.acquire();
+            if (reacquired != releasedSlot) {
+                throw new AssertionError(
+                        "after releasing only slot " + releasedSlot
+                        + ", acquire() must return that same slot, got " + reacquired);
+            }
+
+            pool.release(reacquired, -1);
+            for (int i = 0; i < n; i++) {
+                if (i != rPos) {
+                    pool.release(slots[i], -1);
+                }
+            }
+        } finally {
+            pool.destroy();
+        }
+    }
+}

--- a/app/src/test/java/com/winlator/cmod/renderer/AHardwareBufferPoolProperty3Test.java
+++ b/app/src/test/java/com/winlator/cmod/renderer/AHardwareBufferPoolProperty3Test.java
@@ -1,0 +1,314 @@
+package com.winlator.cmod.renderer;
+
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Pool Size Invariant
+ *
+ * For any pool size N in [1..4] and arbitrary sequences of acquire/release ops:
+ *   - The number of simultaneously acquired (in-flight) slots never exceeds N
+ *   - {@code acquire()} returns -1 when all N slots are in-flight and the
+ *     timeout of {@link AHardwareBufferPool#ACQUIRE_TIMEOUT_MS} elapses
+ *   - The pool never hands out the same slot index twice concurrently
+ */
+public class AHardwareBufferPoolProperty3Test {
+
+    private static AHardwareBufferNativeCalls fakeCalls() {
+        final AtomicLong ptrCounter = new AtomicLong(1000L);
+        return new AHardwareBufferNativeCalls() {
+            @Override
+            public long createBuffer(int width, int height, int format, long usage) {
+                return ptrCounter.getAndIncrement();
+            }
+            @Override public void destroyBuffer(long ptr) {}
+            @Override public int  sendBufferToSocket(long ptr, int fd) { return 0; }
+            @Override public long receiveBufferFromSocket(int fd) { return ptrCounter.getAndIncrement(); }
+            @Override public int  waitFence(int fd, int timeoutMs) { return 0; }
+        };
+    }
+
+    private static AHardwareBufferPool makePool(int n) {
+        AHardwareBufferPool pool = new AHardwareBufferPool(
+                64, 64, n,
+                /* AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM */ 1,
+                /* GPU_FRAMEBUFFER | GPU_SAMPLED_IMAGE | COMPOSER_OVERLAY */ 0x130L,
+                fakeCalls());
+        boolean ok = pool.init();
+        if (!ok) {
+            throw new AssertionError("pool.init() must succeed with fake native calls");
+        }
+        return pool;
+    }
+
+    @Property(tries = 100)
+    void simultaneouslyAcquiredCountNeverExceedsN(
+            @ForAll @IntRange(min = 1, max = 4) int n) {
+
+        AHardwareBufferPool pool = makePool(n);
+        try {
+            boolean[] slotInFlight = new boolean[n];
+            int inFlightCount = 0;
+
+            int[] acquired = new int[n];
+            for (int i = 0; i < n; i++) {
+                int slot = pool.acquire();
+
+                if (slot < 0 || slot >= n) {
+                    throw new AssertionError(
+                            "acquire() call " + i + " must return index in [0, " + n
+                            + "), got " + slot);
+                }
+
+                if (slotInFlight[slot]) {
+                    throw new AssertionError(
+                            "acquire() returned slot " + slot + " which is already in-flight "
+                            + "(duplicate slot handed out concurrently)");
+                }
+
+                slotInFlight[slot] = true;
+                inFlightCount++;
+                acquired[i] = slot;
+
+                if (inFlightCount > n) {
+                    throw new AssertionError(
+                            "in-flight count " + inFlightCount + " exceeds pool size N=" + n);
+                }
+            }
+
+            for (int i = 0; i < n; i++) {
+                pool.release(acquired[i], -1);
+                slotInFlight[acquired[i]] = false;
+                inFlightCount--;
+            }
+
+            if (inFlightCount != 0) {
+                throw new AssertionError(
+                        "in-flight count must be 0 after releasing all slots, got " + inFlightCount);
+            }
+        } finally {
+            pool.destroy();
+        }
+    }
+
+    @Property(tries = 100)
+    void acquireReturnsSentinelWhenPoolExhausted(
+            @ForAll @IntRange(min = 1, max = 4) int n) {
+
+        AHardwareBufferPool pool = makePool(n);
+        try {
+            int[] slots = new int[n];
+            for (int i = 0; i < n; i++) {
+                slots[i] = pool.acquire();
+                if (slots[i] < 0 || slots[i] >= n) {
+                    throw new AssertionError(
+                            "acquire() call " + i + " must succeed while pool has free slots, "
+                            + "got " + slots[i]);
+                }
+            }
+
+            long before = System.currentTimeMillis();
+            int result = pool.acquire();
+            long elapsed = System.currentTimeMillis() - before;
+
+            if (result != -1) {
+                throw new AssertionError(
+                        "acquire() must return -1 when all " + n + " slots are in-flight, got " + result);
+            }
+
+            if (elapsed < AHardwareBufferPool.ACQUIRE_TIMEOUT_MS) {
+                throw new AssertionError(
+                        "acquire() must block for at least ACQUIRE_TIMEOUT_MS="
+                        + AHardwareBufferPool.ACQUIRE_TIMEOUT_MS + " ms before returning -1, "
+                        + "but returned after only " + elapsed + " ms");
+            }
+
+            for (int i = 0; i < n; i++) {
+                pool.release(slots[i], -1);
+            }
+        } finally {
+            pool.destroy();
+        }
+    }
+
+    @Property(tries = 100)
+    void concurrentAcquiresReturnDistinctSlots(
+            @ForAll @IntRange(min = 1, max = 4) int n) throws InterruptedException {
+
+        AHardwareBufferPool pool = makePool(n);
+        try {
+            int[] results = new int[n];
+            CountDownLatch startGate = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(n);
+            AtomicInteger errorCount = new AtomicInteger(0);
+
+            Thread[] threads = new Thread[n];
+            for (int i = 0; i < n; i++) {
+                final int threadIdx = i;
+                threads[i] = new Thread(() -> {
+                    try {
+                        startGate.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        errorCount.incrementAndGet();
+                        doneLatch.countDown();
+                        return;
+                    }
+                    results[threadIdx] = pool.acquire();
+                    doneLatch.countDown();
+                });
+                threads[i].setDaemon(true);
+                threads[i].start();
+            }
+
+            startGate.countDown();
+            doneLatch.await();
+
+            if (errorCount.get() > 0) {
+                throw new AssertionError("One or more acquire threads were interrupted");
+            }
+
+            for (int i = 0; i < n; i++) {
+                if (results[i] < 0 || results[i] >= n) {
+                    throw new AssertionError(
+                            "concurrent acquire() thread " + i
+                            + " must return index in [0, " + n + "), got " + results[i]);
+                }
+            }
+
+            for (int i = 0; i < n; i++) {
+                for (int j = i + 1; j < n; j++) {
+                    if (results[i] == results[j]) {
+                        throw new AssertionError(
+                                "concurrent acquire() returned duplicate slot " + results[i]
+                                + " for threads " + i + " and " + j
+                                + " (pool size N=" + n + ")");
+                    }
+                }
+            }
+
+            for (int i = 0; i < n; i++) {
+                pool.release(results[i], -1);
+            }
+        } finally {
+            pool.destroy();
+        }
+    }
+
+    @Property(tries = 100)
+    void interleavedAcquireReleaseRespectsNSlotCap(
+            @ForAll @IntRange(min = 1, max = 4) int n,
+            @ForAll @IntRange(min = 1, max = 8) int k) {
+
+        AHardwareBufferPool pool = makePool(n);
+        try {
+            List<Integer> inFlight = new ArrayList<>();
+            boolean[] slotUsed = new boolean[n];
+            int maxObservedInFlight = 0;
+
+            for (int round = 0; round < k; round++) {
+                if (inFlight.size() < n) {
+                    int slot = pool.acquire();
+
+                    if (slot < 0 || slot >= n) {
+                        throw new AssertionError(
+                                "round " + round + ": acquire() must return index in [0, " + n
+                                + "), got " + slot + " (in-flight=" + inFlight.size() + ")");
+                    }
+
+                    if (slotUsed[slot]) {
+                        throw new AssertionError(
+                                "round " + round + ": acquire() returned slot " + slot
+                                + " which is already in-flight");
+                    }
+
+                    slotUsed[slot] = true;
+                    inFlight.add(slot);
+
+                    int currentInFlight = inFlight.size();
+                    if (currentInFlight > maxObservedInFlight) {
+                        maxObservedInFlight = currentInFlight;
+                    }
+
+                    if (currentInFlight > n) {
+                        throw new AssertionError(
+                                "round " + round + ": in-flight count " + currentInFlight
+                                + " exceeds pool size N=" + n);
+                    }
+                }
+
+                if (!inFlight.isEmpty() && (round % 2 == 1 || inFlight.size() == n)) {
+                    int toRelease = inFlight.remove(0);
+                    slotUsed[toRelease] = false;
+                    pool.release(toRelease, -1);
+                }
+            }
+
+            for (int slot : inFlight) {
+                pool.release(slot, -1);
+            }
+
+            if (maxObservedInFlight > n) {
+                throw new AssertionError(
+                        "max observed in-flight count " + maxObservedInFlight
+                        + " exceeded pool size N=" + n);
+            }
+        } finally {
+            pool.destroy();
+        }
+    }
+
+    @Property(tries = 100)
+    void acquireUnblocksWhenSlotReleasedBeforeTimeout(
+            @ForAll @IntRange(min = 1, max = 4) int n) throws InterruptedException {
+
+        AHardwareBufferPool pool = makePool(n);
+        try {
+            int[] slots = new int[n];
+            for (int i = 0; i < n; i++) {
+                slots[i] = pool.acquire();
+                if (slots[i] < 0 || slots[i] >= n) {
+                    throw new AssertionError(
+                            "initial acquire() call " + i + " must succeed, got " + slots[i]);
+                }
+            }
+
+            long releaseDelayMs = AHardwareBufferPool.ACQUIRE_TIMEOUT_MS / 2;
+            final int slotToRelease = slots[0];
+            Thread releaser = new Thread(() -> {
+                try {
+                    Thread.sleep(releaseDelayMs);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                pool.release(slotToRelease, -1);
+            });
+            releaser.setDaemon(true);
+            releaser.start();
+
+            int result = pool.acquire();
+
+            if (result < 0 || result >= n) {
+                throw new AssertionError(
+                        "acquire() must return a valid slot index in [0, " + n
+                        + ") when a slot is released before the timeout, got " + result);
+            }
+
+            releaser.join(AHardwareBufferPool.ACQUIRE_TIMEOUT_MS * 2);
+
+            pool.release(result, -1);
+            for (int i = 1; i < n; i++) {
+                pool.release(slots[i], -1);
+            }
+        } finally {
+            pool.destroy();
+        }
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,70 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(WinlatorTests CXX C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+# ── RapidCheck via FetchContent ───────────────────────────────────────────────
+include(FetchContent)
+
+FetchContent_Declare(
+    rapidcheck
+    GIT_REPOSITORY https://github.com/emil-e/rapidcheck.git
+    GIT_TAG        master
+    GIT_SHALLOW    TRUE
+)
+set(RC_ENABLE_GTEST ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(rapidcheck)
+
+# ── GoogleTest via FetchContent ───────────────────────────────────────────────
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        v1.14.0
+    GIT_SHALLOW    TRUE
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+# ── Mock NDK headers ──────────────────────────────────────────────────────────
+# The mock headers are in tests/mock_ndk/ and provide stub implementations
+# of Android NDK APIs (AHardwareBuffer, android/log.h, sync/sync.h, jni.h)
+# so that ahb_bridge.c can be compiled and tested on the host.
+
+set(MOCK_NDK_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mock_ndk")
+
+# ── Property 13: JNI Bridge Error Sentinel ────────────────────────────────────
+add_executable(test_ahb_bridge_property13
+    prop13_jni_bridge_error_sentinel.cpp
+    mock_ndk_impl.cpp
+    # Compile ahb_bridge.c with mocked NDK headers
+    "${CMAKE_CURRENT_SOURCE_DIR}/../app/src/main/cpp/winlator/ahb_bridge.c"
+)
+
+target_include_directories(test_ahb_bridge_property13 PRIVATE
+    "${MOCK_NDK_INCLUDE_DIR}"
+)
+
+target_compile_definitions(test_ahb_bridge_property13 PRIVATE
+    # Tell the mock headers to use the controllable failure injection
+    AHB_BRIDGE_TEST_MODE=1
+    # Suppress MSVC deprecation warnings for strncpy, vsnprintf, etc.
+    $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
+)
+
+target_compile_options(test_ahb_bridge_property13 PRIVATE
+    # Suppress warnings from the mock headers and test code
+    $<$<CXX_COMPILER_ID:MSVC>:/W3 /wd4100 /wd4505>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers>
+)
+
+target_link_libraries(test_ahb_bridge_property13 PRIVATE
+    rapidcheck
+    rapidcheck_gtest
+    GTest::gtest_main
+)
+
+include(CTest)
+enable_testing()
+include(GoogleTest)
+gtest_discover_tests(test_ahb_bridge_property13)

--- a/tests/mock_ndk/ahb_internal.h
+++ b/tests/mock_ndk/ahb_internal.h
@@ -1,0 +1,23 @@
+/*
+ * mock_ndk/ahb_internal.h — Internal AHardwareBuffer struct definition for tests.
+ *
+ * This header defines the concrete AHardwareBuffer struct used by the mock
+ * implementation. It must be included BEFORE android/hardware_buffer.h in
+ * any translation unit that needs to allocate or inspect AHardwareBuffer objects.
+ *
+ * ahb_bridge.c only uses AHardwareBuffer as an opaque pointer and never
+ * includes this header — it only sees the forward declaration from
+ * android/hardware_buffer.h.
+ */
+#pragma once
+
+#include <stdint.h>
+
+struct AHardwareBuffer {
+    uint32_t width;
+    uint32_t height;
+    uint32_t layers;
+    uint32_t format;
+    uint64_t usage;
+    int      refcount;
+};

--- a/tests/mock_ndk/android/hardware_buffer.h
+++ b/tests/mock_ndk/android/hardware_buffer.h
@@ -1,0 +1,68 @@
+/*
+ * mock_ndk/android/hardware_buffer.h — Controllable mock for AHardwareBuffer NDK API.
+ *
+ * In test mode (AHB_BRIDGE_TEST_MODE=1), the functions delegate to
+ * mock_ahb_* function pointers that the test can swap out to inject failures.
+ */
+#pragma once
+
+#include <stdint.h>
+
+/* ── AHardwareBuffer_Desc ─────────────────────────────────────────────────── */
+typedef struct AHardwareBuffer_Desc {
+    uint32_t width;
+    uint32_t height;
+    uint32_t layers;
+    uint32_t format;
+    uint64_t usage;
+    uint32_t stride;
+    uint32_t rfu0;
+    uint64_t rfu1;
+} AHardwareBuffer_Desc;
+
+/* Opaque handle — forward declaration only in the public header */
+typedef struct AHardwareBuffer AHardwareBuffer;
+
+/* ── Mock control (only compiled in test mode) ───────────────────────────── */
+#ifdef AHB_BRIDGE_TEST_MODE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Function pointers that the test replaces to inject failures.
+ * Default implementations (set in mock_ndk_init()) behave like the real NDK.
+ */
+extern int  (*mock_AHardwareBuffer_allocate)(const AHardwareBuffer_Desc*, AHardwareBuffer**);
+extern void (*mock_AHardwareBuffer_release)(AHardwareBuffer*);
+extern void (*mock_AHardwareBuffer_acquire)(AHardwareBuffer*);
+extern int  (*mock_AHardwareBuffer_sendHandleToUnixSocket)(const AHardwareBuffer*, int);
+extern int  (*mock_AHardwareBuffer_recvHandleFromUnixSocket)(int, AHardwareBuffer**);
+
+/* Call this once before tests to set up default (passing) implementations. */
+void mock_ndk_init(void);
+
+/* Convenience: reset all mocks to their default (passing) implementations. */
+void mock_ndk_reset(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/* ── Macro shims: redirect NDK calls to mock function pointers ─────────────── */
+#define AHardwareBuffer_allocate(desc, out)                  mock_AHardwareBuffer_allocate((desc), (out))
+#define AHardwareBuffer_release(ahb)                         mock_AHardwareBuffer_release((ahb))
+#define AHardwareBuffer_acquire(ahb)                         mock_AHardwareBuffer_acquire((ahb))
+#define AHardwareBuffer_sendHandleToUnixSocket(ahb, fd)      mock_AHardwareBuffer_sendHandleToUnixSocket((ahb), (fd))
+#define AHardwareBuffer_recvHandleFromUnixSocket(fd, out)    mock_AHardwareBuffer_recvHandleFromUnixSocket((fd), (out))
+
+#else /* !AHB_BRIDGE_TEST_MODE — real NDK declarations */
+
+int  AHardwareBuffer_allocate(const AHardwareBuffer_Desc* desc, AHardwareBuffer** outBuffer);
+void AHardwareBuffer_release(AHardwareBuffer* buffer);
+void AHardwareBuffer_acquire(AHardwareBuffer* buffer);
+int  AHardwareBuffer_sendHandleToUnixSocket(const AHardwareBuffer* buffer, int socketFd);
+int  AHardwareBuffer_recvHandleFromUnixSocket(int socketFd, AHardwareBuffer** outBuffer);
+
+#endif /* AHB_BRIDGE_TEST_MODE */

--- a/tests/mock_ndk/android/log.h
+++ b/tests/mock_ndk/android/log.h
@@ -1,0 +1,86 @@
+/*
+ * mock_ndk/android/log.h — Controllable mock for Android logging API.
+ *
+ * Captures log calls so tests can verify that "AHB_Bridge" appears in
+ * the tag and that the correct log level is used.
+ */
+#pragma once
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Android log priority levels (matches android/log.h) */
+typedef enum android_LogPriority {
+    ANDROID_LOG_UNKNOWN = 0,
+    ANDROID_LOG_DEFAULT,
+    ANDROID_LOG_VERBOSE,
+    ANDROID_LOG_DEBUG,
+    ANDROID_LOG_INFO,
+    ANDROID_LOG_WARN,
+    ANDROID_LOG_ERROR,
+    ANDROID_LOG_FATAL,
+    ANDROID_LOG_SILENT,
+} android_LogPriority;
+
+/* ── Log capture infrastructure ─────────────────────────────────────────── */
+#ifdef AHB_BRIDGE_TEST_MODE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MOCK_LOG_MAX_ENTRIES  64
+#define MOCK_LOG_MAX_MSG_LEN  512
+#define MOCK_LOG_MAX_TAG_LEN  64
+
+typedef struct MockLogEntry {
+    int  priority;
+    char tag[MOCK_LOG_MAX_TAG_LEN];
+    char message[MOCK_LOG_MAX_MSG_LEN];
+} MockLogEntry;
+
+extern MockLogEntry mock_log_entries[MOCK_LOG_MAX_ENTRIES];
+extern int          mock_log_count;
+
+/* Reset the captured log buffer. */
+void mock_log_reset(void);
+
+/*
+ * Returns 1 if any captured log entry has the given tag and the message
+ * contains the given substring. Returns 0 otherwise.
+ */
+int mock_log_contains(const char* tag, const char* substring);
+
+/*
+ * Returns 1 if any captured log entry has the given tag, the given priority,
+ * and the message contains the given substring.
+ */
+int mock_log_contains_with_priority(int priority, const char* tag, const char* substring);
+
+#ifdef __cplusplus
+}
+#endif
+
+/* ── Macro shim: redirect __android_log_print to our capture function ─────── */
+static inline int __mock_android_log_print(int prio, const char* tag, const char* fmt, ...) {
+    if (mock_log_count < MOCK_LOG_MAX_ENTRIES) {
+        MockLogEntry* e = &mock_log_entries[mock_log_count++];
+        e->priority = prio;
+        strncpy(e->tag, tag ? tag : "", MOCK_LOG_MAX_TAG_LEN - 1);
+        e->tag[MOCK_LOG_MAX_TAG_LEN - 1] = '\0';
+        va_list ap;
+        va_start(ap, fmt);
+        vsnprintf(e->message, MOCK_LOG_MAX_MSG_LEN, fmt, ap);
+        va_end(ap);
+    }
+    return 0;
+}
+
+#define __android_log_print(prio, tag, ...) __mock_android_log_print((prio), (tag), __VA_ARGS__)
+
+#else /* !AHB_BRIDGE_TEST_MODE */
+
+int __android_log_print(int prio, const char* tag, const char* fmt, ...);
+
+#endif /* AHB_BRIDGE_TEST_MODE */

--- a/tests/mock_ndk/jni.h
+++ b/tests/mock_ndk/jni.h
@@ -1,0 +1,45 @@
+/*
+ * mock_ndk/jni.h — Minimal JNI type definitions for host-side testing.
+ *
+ * Provides just enough of the JNI API surface to compile ahb_bridge.c
+ * without the Android NDK.
+ */
+#pragma once
+
+#include <stdint.h>
+
+/* Primitive JNI types */
+typedef uint8_t  jboolean;
+typedef int8_t   jbyte;
+typedef uint16_t jchar;
+typedef int16_t  jshort;
+typedef int32_t  jint;
+typedef int64_t  jlong;
+typedef float    jfloat;
+typedef double   jdouble;
+typedef void*    jobject;
+typedef jobject  jclass;
+typedef jobject  jstring;
+typedef jobject  jarray;
+typedef jarray   jintArray;
+typedef void     jvoid;
+
+/* JNIEnv stub — ahb_bridge.c only uses env for (void)env casts */
+typedef struct JNINativeInterface_ JNINativeInterface_;
+typedef const JNINativeInterface_* JNIEnv;
+
+struct JNINativeInterface_ {
+    void* reserved0;
+    void* reserved1;
+    void* reserved2;
+    void* reserved3;
+};
+
+/* JNIEXPORT / JNICALL */
+#ifdef _MSC_VER
+#  define JNIEXPORT __declspec(dllexport)
+#  define JNICALL   __cdecl
+#else
+#  define JNIEXPORT __attribute__((visibility("default")))
+#  define JNICALL
+#endif

--- a/tests/mock_ndk/sync/sync.h
+++ b/tests/mock_ndk/sync/sync.h
@@ -1,0 +1,28 @@
+/*
+ * mock_ndk/sync/sync.h — Controllable mock for Android sync fence API.
+ *
+ * In test mode, sync_wait delegates to a replaceable function pointer
+ * so tests can inject timeout/error conditions.
+ */
+#pragma once
+
+#ifdef AHB_BRIDGE_TEST_MODE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Replaceable mock: default returns 0 (success). */
+extern int (*mock_sync_wait)(int fd, int timeout);
+
+#ifdef __cplusplus
+}
+#endif
+
+#define sync_wait(fd, timeout)  mock_sync_wait((fd), (timeout))
+
+#else /* !AHB_BRIDGE_TEST_MODE */
+
+int sync_wait(int fd, int timeout);
+
+#endif /* AHB_BRIDGE_TEST_MODE */

--- a/tests/mock_ndk/unistd.h
+++ b/tests/mock_ndk/unistd.h
@@ -1,0 +1,36 @@
+/*
+ * mock_ndk/unistd.h — Minimal unistd.h stub for Windows host-side testing.
+ *
+ * On Linux/macOS, the real unistd.h is used. On Windows (MSVC), this stub
+ * provides the close() function needed by ahb_bridge.c.
+ *
+ * ahb_bridge.c calls close(fd) after sync_wait to close the fence fd.
+ * In test mode, the fd values are arbitrary integers (not real file descriptors),
+ * so we provide a no-op close() that doesn't actually close anything.
+ */
+#pragma once
+
+#ifdef _WIN32
+
+#ifdef AHB_BRIDGE_TEST_MODE
+
+/*
+ * In test mode, close() is a no-op because the test passes arbitrary integer
+ * fd values that are not real file descriptors.
+ *
+ * We define close as a macro BEFORE including any system headers that might
+ * define it, so our definition takes precedence.
+ */
+#define close(fd) ((void)(fd), 0)
+
+#else /* !AHB_BRIDGE_TEST_MODE */
+
+/* Outside test mode, map close() to the Windows _close() */
+#include <io.h>
+#ifndef close
+#  define close(fd) _close(fd)
+#endif
+
+#endif /* AHB_BRIDGE_TEST_MODE */
+
+#endif /* _WIN32 */

--- a/tests/mock_ndk_impl.cpp
+++ b/tests/mock_ndk_impl.cpp
@@ -1,0 +1,138 @@
+/*
+ * mock_ndk_impl.cpp — Implementations of the mock NDK function pointers and
+ * log capture infrastructure used by the AHB bridge host-side tests.
+ *
+ * Feature: direct-android-compositing
+ */
+
+#include <cstdlib>
+#include <cstring>
+#include <cstdio>
+
+/*
+ * Include the internal AHardwareBuffer struct definition BEFORE the mock
+ * hardware_buffer.h so the struct is fully defined when the typedef is seen.
+ */
+#include "mock_ndk/ahb_internal.h"
+
+/* Pull in the mock headers (with AHB_BRIDGE_TEST_MODE defined by the build) */
+#include "mock_ndk/android/hardware_buffer.h"
+#include "mock_ndk/android/log.h"
+#include "mock_ndk/sync/sync.h"
+
+/* ── Log capture state ──────────────────────────────────────────────────── */
+MockLogEntry mock_log_entries[MOCK_LOG_MAX_ENTRIES];
+int          mock_log_count = 0;
+
+extern "C" void mock_log_reset(void) {
+    mock_log_count = 0;
+    memset(mock_log_entries, 0, sizeof(mock_log_entries));
+}
+
+extern "C" int mock_log_contains(const char* tag, const char* substring) {
+    for (int i = 0; i < mock_log_count; ++i) {
+        if (strcmp(mock_log_entries[i].tag, tag) == 0 &&
+            strstr(mock_log_entries[i].message, substring) != nullptr) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+extern "C" int mock_log_contains_with_priority(int priority, const char* tag, const char* substring) {
+    for (int i = 0; i < mock_log_count; ++i) {
+        if (mock_log_entries[i].priority == priority &&
+            strcmp(mock_log_entries[i].tag, tag) == 0 &&
+            strstr(mock_log_entries[i].message, substring) != nullptr) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* ── Default (passing) AHardwareBuffer implementations ─────────────────── */
+
+/*
+ * A minimal heap-allocated AHardwareBuffer stand-in.
+ * The real NDK type is opaque; for testing we just need a non-null pointer.
+ * The struct is defined at the top of this file before the mock headers.
+ */
+
+static int default_AHardwareBuffer_allocate(
+        const AHardwareBuffer_Desc* desc, AHardwareBuffer** out) {
+    AHardwareBuffer* ahb = (AHardwareBuffer*)malloc(sizeof(AHardwareBuffer));
+    if (!ahb) return -1;
+    ahb->width    = desc->width;
+    ahb->height   = desc->height;
+    ahb->layers   = desc->layers;
+    ahb->format   = desc->format;
+    ahb->usage    = desc->usage;
+    ahb->refcount = 1;
+    *out = ahb;
+    return 0;
+}
+
+static void default_AHardwareBuffer_release(AHardwareBuffer* ahb) {
+    if (!ahb) return;
+    ahb->refcount--;
+    if (ahb->refcount <= 0) free(ahb);
+}
+
+static void default_AHardwareBuffer_acquire(AHardwareBuffer* ahb) {
+    if (ahb) ahb->refcount++;
+}
+
+static int default_AHardwareBuffer_sendHandleToUnixSocket(
+        const AHardwareBuffer* /*ahb*/, int /*fd*/) {
+    return 0; /* success */
+}
+
+static int default_AHardwareBuffer_recvHandleFromUnixSocket(
+        int /*fd*/, AHardwareBuffer** out) {
+    /* Return a freshly allocated buffer as a stand-in */
+    AHardwareBuffer* ahb = (AHardwareBuffer*)malloc(sizeof(AHardwareBuffer));
+    if (!ahb) return -1;
+    memset(ahb, 0, sizeof(*ahb));
+    ahb->refcount = 1;
+    *out = ahb;
+    return 0;
+}
+
+/* ── Default sync_wait implementation ──────────────────────────────────── */
+static int default_sync_wait(int /*fd*/, int /*timeout*/) {
+    return 0; /* success */
+}
+
+/* ── Function pointer definitions ───────────────────────────────────────── */
+int  (*mock_AHardwareBuffer_allocate)(const AHardwareBuffer_Desc*, AHardwareBuffer**)
+    = default_AHardwareBuffer_allocate;
+
+void (*mock_AHardwareBuffer_release)(AHardwareBuffer*)
+    = default_AHardwareBuffer_release;
+
+void (*mock_AHardwareBuffer_acquire)(AHardwareBuffer*)
+    = default_AHardwareBuffer_acquire;
+
+int  (*mock_AHardwareBuffer_sendHandleToUnixSocket)(const AHardwareBuffer*, int)
+    = default_AHardwareBuffer_sendHandleToUnixSocket;
+
+int  (*mock_AHardwareBuffer_recvHandleFromUnixSocket)(int, AHardwareBuffer**)
+    = default_AHardwareBuffer_recvHandleFromUnixSocket;
+
+int  (*mock_sync_wait)(int, int)
+    = default_sync_wait;
+
+/* ── Init / reset helpers ───────────────────────────────────────────────── */
+extern "C" void mock_ndk_init(void) {
+    mock_ndk_reset();
+}
+
+extern "C" void mock_ndk_reset(void) {
+    mock_AHardwareBuffer_allocate             = default_AHardwareBuffer_allocate;
+    mock_AHardwareBuffer_release              = default_AHardwareBuffer_release;
+    mock_AHardwareBuffer_acquire              = default_AHardwareBuffer_acquire;
+    mock_AHardwareBuffer_sendHandleToUnixSocket   = default_AHardwareBuffer_sendHandleToUnixSocket;
+    mock_AHardwareBuffer_recvHandleFromUnixSocket = default_AHardwareBuffer_recvHandleFromUnixSocket;
+    mock_sync_wait                            = default_sync_wait;
+    mock_log_reset();
+}

--- a/tests/prop13_jni_bridge_error_sentinel.cpp
+++ b/tests/prop13_jni_bridge_error_sentinel.cpp
@@ -1,0 +1,411 @@
+/*
+ * prop13_jni_bridge_error_sentinel.cpp
+ *
+ * JNI Bridge Error Sentinel tests
+ * ────────────────────────────────
+ * For each JNI function, inject NDK failure via mock, verify sentinel returned
+ * and log message contains "AHB_Bridge".
+ *
+ * Testing framework: rapidcheck + GoogleTest
+ * Minimum iterations: 100 (configured via RC_PARAMS env var or rapidcheck defaults)
+ */
+
+#include <gtest/gtest.h>
+#include <rapidcheck.h>
+#include <rapidcheck/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <climits>
+
+/* ── Pull in mock NDK headers ─────────────────────────────────────────────── */
+#include "mock_ndk/ahb_internal.h"   /* AHardwareBuffer struct (for test-side alloc) */
+#include "mock_ndk/android/hardware_buffer.h"
+#include "mock_ndk/android/log.h"
+#include "mock_ndk/sync/sync.h"
+
+/* ── Forward-declare the JNI functions under test ────────────────────────── */
+/*
+ * ahb_bridge.c is compiled into this test binary. We declare the JNI
+ * function signatures here so we can call them directly without going
+ * through the JVM.
+ *
+ * JNIEnv* and jclass are both void* in our minimal jni.h, so passing
+ * nullptr is safe — ahb_bridge.c casts them to (void) immediately.
+ */
+#include "mock_ndk/jni.h"
+
+extern "C" {
+
+jlong Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeCreateBuffer(
+        JNIEnv* env, jclass cls,
+        jint width, jint height, jint format, jlong usage);
+
+void Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeDestroyBuffer(
+        JNIEnv* env, jclass cls, jlong ptr);
+
+jint Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeSendBufferToSocket(
+        JNIEnv* env, jclass cls, jlong ptr, jint fd);
+
+jlong Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeReceiveBufferFromSocket(
+        JNIEnv* env, jclass cls, jint fd);
+
+jint Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeWaitFence(
+        JNIEnv* env, jclass cls, jint fd, jint timeoutMs);
+
+} /* extern "C" */
+
+/* ── Convenience aliases ─────────────────────────────────────────────────── */
+static JNIEnv* const kEnv = nullptr;
+static jclass  const kCls = nullptr;
+
+/* ── Test fixture: resets all mocks before each test ─────────────────────── */
+class AhbBridgeTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        mock_ndk_reset();
+    }
+    void TearDown() override {
+        mock_ndk_reset();
+    }
+};
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * For any (width, height, format, usage), when AHardwareBuffer_allocate is
+ * injected to fail, nativeCreateBuffer SHALL return 0 and SHALL log with
+ * tag "AHB_Bridge".
+ * ═══════════════════════════════════════════════════════════════════════════ */
+RC_GTEST_FIXTURE_PROP(AhbBridgeTest, CreateBuffer_AllocateFailure_ReturnsSentinel, ()) {
+    const jint  width  = *rc::gen::inRange<jint>(1, 4096);
+    const jint  height = *rc::gen::inRange<jint>(1, 4096);
+    const jint  format = *rc::gen::inRange<jint>(1, 32);
+    const jlong usage  = *rc::gen::inRange<jlong>(0LL, (jlong)0xFFFFFFFFLL);
+
+    mock_AHardwareBuffer_allocate = [](const AHardwareBuffer_Desc*, AHardwareBuffer**) -> int {
+        return -1;
+    };
+    mock_log_reset();
+
+    jlong result = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeCreateBuffer(
+            kEnv, kCls, width, height, format, usage);
+
+    RC_ASSERT(result == 0);
+    RC_ASSERT(mock_log_contains("AHB_Bridge", "") == 1);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Even if allocate returns 0 (success code) but sets *out = NULL, the
+ * function must still return the sentinel 0 and log.
+ * ═══════════════════════════════════════════════════════════════════════════ */
+RC_GTEST_FIXTURE_PROP(AhbBridgeTest, CreateBuffer_NullBufferFromAllocate_ReturnsSentinel, ()) {
+    const jint  width  = *rc::gen::inRange<jint>(1, 4096);
+    const jint  height = *rc::gen::inRange<jint>(1, 4096);
+    const jint  format = *rc::gen::inRange<jint>(1, 32);
+    const jlong usage  = *rc::gen::inRange<jlong>(0LL, (jlong)0xFFFFFFFFLL);
+
+    mock_AHardwareBuffer_allocate = [](const AHardwareBuffer_Desc*, AHardwareBuffer** out) -> int {
+        *out = nullptr;
+        return 0;
+    };
+    mock_log_reset();
+
+    jlong result = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeCreateBuffer(
+            kEnv, kCls, width, height, format, usage);
+
+    RC_ASSERT(result == 0);
+    RC_ASSERT(mock_log_contains("AHB_Bridge", "") == 1);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * nativeSendBufferToSocket returns -1 on NDK failure
+ *
+ * For any (ptr, fd), when AHardwareBuffer_sendHandleToUnixSocket fails,
+ * nativeSendBufferToSocket SHALL return -1 and log with tag "AHB_Bridge".
+ * ═══════════════════════════════════════════════════════════════════════════ */
+RC_GTEST_FIXTURE_PROP(AhbBridgeTest, SendBufferToSocket_SendFailure_ReturnsSentinel, ()) {
+    AHardwareBuffer* ahb = nullptr;
+    {
+        AHardwareBuffer_Desc desc{};
+        desc.width = 64; desc.height = 64; desc.layers = 1;
+        desc.format = 1; desc.usage = 3;
+        mock_AHardwareBuffer_allocate(&desc, &ahb);
+    }
+    RC_PRE(ahb != nullptr);
+
+    const jlong ptr = (jlong)(uintptr_t)ahb;
+    const jint  fd  = *rc::gen::inRange<jint>(0, 1023);
+
+    mock_AHardwareBuffer_sendHandleToUnixSocket = [](const AHardwareBuffer*, int) -> int {
+        return -1;
+    };
+    mock_log_reset();
+
+    jint result = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeSendBufferToSocket(
+            kEnv, kCls, ptr, fd);
+
+    RC_ASSERT(result == -1);
+    RC_ASSERT(mock_log_contains("AHB_Bridge", "") == 1);
+
+    mock_AHardwareBuffer_release(ahb);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * nativeSendBufferToSocket returns -1 on null pointer input
+ *
+ * When ptr == 0, nativeSendBufferToSocket SHALL return -1 and log with
+ * tag "AHB_Bridge" (null-pointer guard path).
+ * ═══════════════════════════════════════════════════════════════════════════ */
+RC_GTEST_FIXTURE_PROP(AhbBridgeTest, SendBufferToSocket_NullPtr_ReturnsSentinel, ()) {
+    const jint fd = *rc::gen::inRange<jint>(0, 1023);
+    mock_log_reset();
+
+    jint result = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeSendBufferToSocket(
+            kEnv, kCls, (jlong)0, fd);
+
+    RC_ASSERT(result == -1);
+    RC_ASSERT(mock_log_contains("AHB_Bridge", "") == 1);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * nativeReceiveBufferFromSocket returns 0 on NDK failure
+ *
+ * For any fd, when AHardwareBuffer_recvHandleFromUnixSocket fails,
+ * nativeReceiveBufferFromSocket SHALL return 0 and log with tag "AHB_Bridge".
+ * ═══════════════════════════════════════════════════════════════════════════ */
+RC_GTEST_FIXTURE_PROP(AhbBridgeTest, ReceiveBufferFromSocket_RecvFailure_ReturnsSentinel, ()) {
+    const jint fd = *rc::gen::inRange<jint>(0, 1023);
+
+    mock_AHardwareBuffer_recvHandleFromUnixSocket = [](int, AHardwareBuffer**) -> int {
+        return -1;
+    };
+    mock_log_reset();
+
+    jlong result = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeReceiveBufferFromSocket(
+            kEnv, kCls, fd);
+
+    RC_ASSERT(result == 0);
+    RC_ASSERT(mock_log_contains("AHB_Bridge", "") == 1);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * nativeReceiveBufferFromSocket returns 0 when recv yields null
+ *
+ * When recvHandleFromUnixSocket "succeeds" but sets *out = NULL, the
+ * function must still return 0 and log.
+ * ═══════════════════════════════════════════════════════════════════════════ */
+RC_GTEST_FIXTURE_PROP(AhbBridgeTest, ReceiveBufferFromSocket_NullBufferFromRecv_ReturnsSentinel, ()) {
+    const jint fd = *rc::gen::inRange<jint>(0, 1023);
+
+    mock_AHardwareBuffer_recvHandleFromUnixSocket = [](int, AHardwareBuffer** out) -> int {
+        *out = nullptr;
+        return 0;
+    };
+    mock_log_reset();
+
+    jlong result = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeReceiveBufferFromSocket(
+            kEnv, kCls, fd);
+
+    RC_ASSERT(result == 0);
+    RC_ASSERT(mock_log_contains("AHB_Bridge", "") == 1);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * nativeWaitFence returns -1 on sync_wait failure
+ *
+ * For any (fd >= 0, timeoutMs), when sync_wait fails (returns < 0),
+ * nativeWaitFence SHALL return -1 and log with tag "AHB_Bridge".
+ * ═══════════════════════════════════════════════════════════════════════════ */
+RC_GTEST_FIXTURE_PROP(AhbBridgeTest, WaitFence_SyncWaitFailure_ReturnsSentinel, ()) {
+    /* fd must be >= 0 to reach the sync_wait call (fd < 0 is the "no fence" fast path) */
+    const jint fd        = *rc::gen::inRange<jint>(0, 1023);
+    const jint timeoutMs = *rc::gen::inRange<jint>(0, 10000);
+
+    mock_sync_wait = [](int, int) -> int {
+        return -1;
+    };
+    mock_log_reset();
+
+    jint result = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeWaitFence(
+            kEnv, kCls, fd, timeoutMs);
+
+    RC_ASSERT(result == -1);
+    RC_ASSERT(mock_log_contains("AHB_Bridge", "") == 1);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * nativeWaitFence with fd < 0 returns 0 (no-fence fast path)
+ *
+ * This is not a failure path — it's the "no fence to wait on" case.
+ * Verifying it doesn't log an error and returns success.
+ * ═══════════════════════════════════════════════════════════════════════════ */
+TEST_F(AhbBridgeTest, WaitFence_NegativeFd_ReturnsSuccess) {
+    mock_log_reset();
+
+    jint result = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeWaitFence(
+            kEnv, kCls, (jint)-1, (jint)16);
+
+    EXPECT_EQ(result, 0);
+    EXPECT_EQ(mock_log_count, 0);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * nativeCreateBuffer succeeds with valid inputs (sanity check)
+ * ═══════════════════════════════════════════════════════════════════════════ */
+TEST_F(AhbBridgeTest, CreateBuffer_ValidInputs_ReturnsNonZero) {
+    mock_log_reset();
+
+    jlong result = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeCreateBuffer(
+            kEnv, kCls, (jint)1920, (jint)1080, (jint)1, (jlong)0x33);
+
+    EXPECT_NE(result, 0);
+    EXPECT_EQ(mock_log_count, 0);
+
+    Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeDestroyBuffer(
+            kEnv, kCls, result);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * nativeSendBufferToSocket succeeds with valid inputs (sanity check)
+ * ═══════════════════════════════════════════════════════════════════════════ */
+TEST_F(AhbBridgeTest, SendBufferToSocket_ValidInputs_ReturnsZero) {
+    jlong ptr = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeCreateBuffer(
+            kEnv, kCls, (jint)64, (jint)64, (jint)1, (jlong)0x33);
+    ASSERT_NE(ptr, 0);
+
+    mock_log_reset();
+
+    jint result = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeSendBufferToSocket(
+            kEnv, kCls, ptr, (jint)5);
+
+    EXPECT_EQ(result, 0);
+    EXPECT_EQ(mock_log_count, 0);
+
+    Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeDestroyBuffer(kEnv, kCls, ptr);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * nativeReceiveBufferFromSocket succeeds with valid inputs
+ * ═══════════════════════════════════════════════════════════════════════════ */
+TEST_F(AhbBridgeTest, ReceiveBufferFromSocket_ValidInputs_ReturnsNonZero) {
+    mock_log_reset();
+
+    jlong result = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeReceiveBufferFromSocket(
+            kEnv, kCls, (jint)5);
+
+    EXPECT_NE(result, 0);
+    EXPECT_EQ(mock_log_count, 0);
+
+    Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeDestroyBuffer(kEnv, kCls, result);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * nativeWaitFence succeeds with valid fd (sanity check)
+ * ═══════════════════════════════════════════════════════════════════════════ */
+TEST_F(AhbBridgeTest, WaitFence_ValidFd_ReturnsZero) {
+    mock_log_reset();
+
+    jint result = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeWaitFence(
+            kEnv, kCls, (jint)5, (jint)16);
+
+    EXPECT_EQ(result, 0);
+    EXPECT_EQ(mock_log_count, 0);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Comprehensive: all five JNI functions log "AHB_Bridge" on failure
+ *
+ * Sweeps over all five functions and verifies the invariant holds for each
+ * one with arbitrary inputs.
+ * ═══════════════════════════════════════════════════════════════════════════ */
+RC_GTEST_FIXTURE_PROP(AhbBridgeTest, AllFunctions_OnNdkFailure_LogTagIsAhbBridge, ()) {
+    const int func_idx = *rc::gen::inRange<int>(0, 5);
+
+    const jint  width   = *rc::gen::inRange<jint>(1, 4096);
+    const jint  height  = *rc::gen::inRange<jint>(1, 4096);
+    const jint  format  = *rc::gen::inRange<jint>(1, 32);
+    const jlong usage   = *rc::gen::inRange<jlong>(0LL, (jlong)0xFFFFFFFFLL);
+    const jint  fd      = *rc::gen::inRange<jint>(0, 1023);
+    const jint  timeout = *rc::gen::inRange<jint>(0, 10000);
+
+    mock_AHardwareBuffer_allocate = [](const AHardwareBuffer_Desc*, AHardwareBuffer**) -> int {
+        return -1;
+    };
+    mock_AHardwareBuffer_sendHandleToUnixSocket = [](const AHardwareBuffer*, int) -> int {
+        return -1;
+    };
+    mock_AHardwareBuffer_recvHandleFromUnixSocket = [](int, AHardwareBuffer**) -> int {
+        return -1;
+    };
+    mock_sync_wait = [](int, int) -> int {
+        return -1;
+    };
+    mock_log_reset();
+
+    bool logged_ahb_bridge = false;
+    bool sentinel_correct  = false;
+
+    switch (func_idx) {
+        case 0: {
+            jlong r = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeCreateBuffer(
+                    kEnv, kCls, width, height, format, usage);
+            sentinel_correct  = (r == 0);
+            logged_ahb_bridge = (mock_log_contains("AHB_Bridge", "") == 1);
+            break;
+        }
+        case 1: {
+            /* null ptr — guaranteed failure path */
+            jint r = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeSendBufferToSocket(
+                    kEnv, kCls, (jlong)0, fd);
+            sentinel_correct  = (r == -1);
+            logged_ahb_bridge = (mock_log_contains("AHB_Bridge", "") == 1);
+            break;
+        }
+        case 2: {
+            /* non-null ptr — NDK failure path; allocate a real buffer first */
+            mock_AHardwareBuffer_allocate = [](const AHardwareBuffer_Desc* d, AHardwareBuffer** out) -> int {
+                AHardwareBuffer* ahb = (AHardwareBuffer*)malloc(sizeof(AHardwareBuffer));
+                if (!ahb) return -1;
+                memset(ahb, 0, sizeof(*ahb));
+                ahb->width = d->width; ahb->height = d->height;
+                ahb->refcount = 1;
+                *out = ahb;
+                return 0;
+            };
+            AHardwareBuffer* ahb = nullptr;
+            AHardwareBuffer_Desc desc{};
+            desc.width = 64; desc.height = 64; desc.layers = 1;
+            desc.format = 1; desc.usage = 3;
+            mock_AHardwareBuffer_allocate(&desc, &ahb);
+            mock_AHardwareBuffer_sendHandleToUnixSocket = [](const AHardwareBuffer*, int) -> int {
+                return -1;
+            };
+            mock_log_reset();
+
+            jlong ptr = (jlong)(uintptr_t)ahb;
+            jint r = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeSendBufferToSocket(
+                    kEnv, kCls, ptr, fd);
+            sentinel_correct  = (r == -1);
+            logged_ahb_bridge = (mock_log_contains("AHB_Bridge", "") == 1);
+            if (ahb) free(ahb);
+            break;
+        }
+        case 3: {
+            jlong r = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeReceiveBufferFromSocket(
+                    kEnv, kCls, fd);
+            sentinel_correct  = (r == 0);
+            logged_ahb_bridge = (mock_log_contains("AHB_Bridge", "") == 1);
+            break;
+        }
+        case 4: {
+            /* fd >= 0 to reach sync_wait */
+            jint r = Java_com_winlator_cmod_renderer_AHardwareBufferPool_nativeWaitFence(
+                    kEnv, kCls, fd, timeout);
+            sentinel_correct  = (r == -1);
+            logged_ahb_bridge = (mock_log_contains("AHB_Bridge", "") == 1);
+            break;
+        }
+    }
+
+    RC_ASSERT(sentinel_correct);
+    RC_ASSERT(logged_ahb_bridge);
+}


### PR DESCRIPTION
## Direct Android Compositing — Phase 1: AHB Bridge & Buffer Pool

This is the first phase of a multi-phase implementation replacing the Java X11 display server path with a zero-copy compositing path for Vulkan-based games (DXVK / VKD3D). Frames will eventually be routed directly from GPU memory to SurfaceFlinger via `AHardwareBuffer` and `SurfaceControl`, reducing input latency and CPU overhead.

**Phase 1 is purely additive.** No existing code paths are modified or activated. There is zero regression risk for current users.

---

### What's in this PR

#### `ahb_bridge.c` — Native JNI bridge (`libwinlator.so`)

Five new JNI functions compiled into `libwinlator.so`:

| Function | NDK call | Sentinel on failure |
|---|---|---|
| `nativeCreateBuffer(w, h, fmt, usage)` | `AHardwareBuffer_allocate` | `0` (null ptr) |
| `nativeDestroyBuffer(ptr)` | `AHardwareBuffer_release` | — |
| `nativeSendBufferToSocket(ptr, fd)` | `AHardwareBuffer_sendHandleToUnixSocket` | `-1` |
| `nativeReceiveBufferFromSocket(fd)` | `AHardwareBuffer_recvHandleFromUnixSocket` | `0` (null ptr) |
| `nativeWaitFence(fd, timeoutMs)` | `sync_wait` from `<sync/sync.h>`, closes `fd` regardless of outcome | `-1` |

All failure paths log with tag `AHB_Bridge`. `nativeWaitFence` has a fast path for `fd < 0` (no fence, returns 0 immediately without logging).

`CMakeLists.txt` updated: `ahb_bridge.c` added to `target_sources(winlator ...)`, `sync` added to `target_link_libraries`.

#### `AHardwareBufferPool.java` — Java buffer pool

Pre-allocates N `AHardwareBuffer` slots at `init()` time and manages them with acquire/release semantics:

- **`acquire()`** — scans for a free slot; if all are in-flight, blocks up to `ACQUIRE_TIMEOUT_MS` (16 ms, one frame at 60 Hz) then returns `-1` and increments a `consecutiveDrops` counter logged in the warning message.
- **`release(index, releaseFenceFd)`** — if `fd == -1`, marks the slot available immediately and calls `notifyAll()`; if `fd >= 0`, submits a task to a cached daemon thread pool (`AHB-FenceWaiter`) that calls `nativeWaitFence` then notifies, keeping the presentation thread non-blocking.
- **`init()` failure handling** — if any allocation fails at slot `k`, all previously allocated slots `0..k-1` are released before returning `false`. The failure sentinel (`0`) is never passed to `nativeDestroyBuffer`.
- **`destroy()`** — shuts down the fence-waiter executor, closes any pending fence fds, and releases all buffers.

Default format: `AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM` (1). Default usage: `GPU_FRAMEBUFFER | GPU_SAMPLED_IMAGE | COMPOSER_OVERLAY` (0x130).

The `AHardwareBufferNativeCalls` interface abstracts the five JNI calls, allowing unit tests to inject a fake implementation without loading `libwinlator.so`.

---

### Tests

#### Java — jqwik property-based tests (`app/src/test/`)

| Test class | What it covers | Iterations |
|---|---|---|
| `AHardwareBufferPoolProperty1Test` | Pool init correctness: count, format, usage, dimensions, `createBuffer` call count and parameters | 100 |
| `AHardwareBufferPoolProperty2Test` | Acquire-release round-trips: single, all-N, repeated cycles, partial release | 100 |
| `AHardwareBufferPoolProperty3Test` | Pool size invariant: in-flight count ≤ N, timeout sentinel, concurrent uniqueness, unblock-on-release | 100 |
| `AHardwareBufferPoolProperty15Test` | `consecutiveDrops` counter increments on each timeout and resets to 0 on next successful acquire; warning log message format | 100 |
| `AHardwareBufferPoolInitFailureTest` | Failure at slot `k` releases exactly `k` buffers and returns `false`; sentinel `0` never destroyed | 100 + 11 spot-checks |

All 27 tests pass. Run with `./gradlew :app:testDebugUnitTest`.

#### C++ — RapidCheck + GoogleTest (`tests/`)

`prop13_jni_bridge_error_sentinel.cpp` tests all five JNI functions in `ahb_bridge.c` via mock NDK headers:

- NDK failure injection (non-zero return / null output pointer) → correct sentinel returned + `AHB_Bridge` log tag present
- Null pointer guard on `nativeSendBufferToSocket`
- `nativeWaitFence` fast path (`fd < 0`) returns 0 with no log output
- Comprehensive sweep property: all five functions, arbitrary inputs, all NDK calls injected to fail

---

### What this PR does NOT include

The following are implemented in later phases and are not present here:

- `DirectCompositorComponent` (lifecycle wiring, API 26 guard)
- `VulkanRenderer` modifications (`setNativeMode`, `SurfaceControl` layer management)
- Wine Vulkan WSI (`vulkan_ahb.c`)
- HUD indicator wiring
- Any activation of the direct path for running games
