### PR TITLE
Fix drives mapped to SD card / USB storage showing up empty

### DIFF
--- a/app/src/main/java/com/winlator/cmod/core/FileUtils.java
+++ b/app/src/main/java/com/winlator/cmod/core/FileUtils.java
@@ -365,9 +365,17 @@ public abstract class FileUtils {
 
         if ("primary".equalsIgnoreCase(type)) {
             return Environment.getExternalStorageDirectory() + "/" + path;
-        } else {
-            return "/mnt/media_rw/" + type + "/" + path;
         }
+
+        // Removable volumes (SD cards, USB OTG) are exposed to apps at /storage/<uuid>.
+        // /mnt/media_rw/<uuid> is the privileged mount owned by the media_rw group, so
+        // neither the app nor the container can read it: the drive is mapped but shows
+        // up empty. Prefer the app-visible path whenever it resolves.
+        String volumePath = "/storage/" + type + (path.isEmpty() ? "" : "/" + path);
+        if (new File(volumePath).exists()) return volumePath;
+
+        Log.w(TAG, volumePath + " is not accessible, falling back to /mnt/media_rw");
+        return "/mnt/media_rw/" + type + "/" + path;
     }
 
 


### PR DESCRIPTION
### Problem

A drive mapped to an SD card or USB OTG volume is created and listed inside the container, but opening it shows an empty folder.

`FileUtils.getFilePathFromUriUsingSAF()` resolves the tree URI returned by `ACTION_OPEN_DOCUMENT_TREE` to a filesystem path. For the primary volume it returns `/storage/emulated/0/...`, which works. For every other volume it returns:

```java
return "/mnt/media_rw/" + type + "/" + path;
```

`/mnt/media_rw/<uuid>` is the privileged mount, owned by the `media_rw` group and readable only by system components such as MediaProvider. The app cannot read it even with `MANAGE_EXTERNAL_STORAGE`, and neither can the container, so the drive is mapped to a path that always appears empty.

### Fix

Removable volumes are exposed to apps at `/storage/<uuid>`. Resolve there first, and fall back to the previous path only when it does not exist, so no existing setup regresses.

```java
String volumePath = "/storage/" + type + (path.isEmpty() ? "" : "/" + path);
if (new File(volumePath).exists()) return volumePath;

Log.w(TAG, volumePath + " is not accessible, falling back to /mnt/media_rw");
return "/mnt/media_rw/" + type + "/" + path;
```

The empty-`path` guard also avoids the trailing slash you'd otherwise get when the whole volume root is picked.

### Notes

- No behaviour change for internal storage or for the default `D:` / `F:` drives.
- Users still need **All files access** granted for the volume to be readable; this change only stops pointing them at a path that can never work.
- Verified `FileUtils.java` compiles against `android-35` with the project sourcepath. Not run on-device — I don't have an SD-card equipped test device to hand.
